### PR TITLE
Per-email nytid time tracking in mutt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ nymutt
 nymutt.sh
 mutt
 mutt.sh
-.muttrc.nymutt
+.muttrc.nytid
 labels.rules
 nymutt.pdf
 nymutt.tex

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,14 @@ edumail.pdf
 edumail.sh
 edumail.tex
 ltxobj/
+mutt-nytid
+mutt-nytid.sh
+mutt
+mutt.sh
+.muttrc.nytid
+labels.rules
+muttnytid.pdf
+muttnytid.tex
 
 
 ## Core latex/pdflatex auxiliary files:

--- a/.gitignore
+++ b/.gitignore
@@ -224,9 +224,11 @@ sympy-plots-for-*.tex/
 *.upa
 *.upb
 
-# pythontex
+# pythontex (latexmk's cus_dep also leaves symlinks to these in the root)
 *.pytxcode
-pythontex-files-*/
+pythontex-files-*
+# latexmk rc symlink created by tex.mk
+latexmkrc
 
 # tcolorbox
 *.listing

--- a/.gitignore
+++ b/.gitignore
@@ -4,14 +4,14 @@ edumail.pdf
 edumail.sh
 edumail.tex
 ltxobj/
-mutt-nytid
-mutt-nytid.sh
+nymutt
+nymutt.sh
 mutt
 mutt.sh
-.muttrc.nytid
+.muttrc.nymutt
 labels.rules
-muttnytid.pdf
-muttnytid.tex
+nymutt.pdf
+nymutt.tex
 
 
 ## Core latex/pdflatex auxiliary files:

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,13 @@ edumail.tex: edumail.nw noweb_lexer.py
 
 nymutt.pdf: nymutt.tex didactic.sty
 nymutt.pdf: preamble.tex
-nymutt.pdf: nymutt edumail .muttrc.nymutt
+nymutt.pdf: nymutt edumail .muttrc.nytid
 
 nymutt.tex: nymutt.nw noweb_lexer.py
 
 
 .PHONY:
-all: edumail nymutt mutt .muttrc.nymutt labels.rules
+all: edumail nymutt mutt .muttrc.nytid labels.rules
 
 edumail.sh: edumail.nw
 edumail: edumail.sh
@@ -27,7 +27,7 @@ edumail: edumail.sh
 nymutt.sh mutt.sh: nymutt.nw
 	${NOTANGLE.sh}
 
-.muttrc.nymutt labels.rules: nymutt.nw
+.muttrc.nytid labels.rules: nymutt.nw
 	${NOTANGLE.sh}
 
 nymutt: nymutt.sh
@@ -43,14 +43,14 @@ mutt: mutt.sh
 clean:
 	${RM} edumail edumail.sh edumail.pdf edumail.tex
 	${RM} nymutt nymutt.sh mutt mutt.sh
-	${RM} .muttrc.nymutt labels.rules nymutt.pdf nymutt.tex
+	${RM} .muttrc.nytid labels.rules nymutt.pdf nymutt.tex
 
 
 .PHONY: install
 PREFIX=${HOME}
-install: edumail nymutt mutt .muttrc.nymutt labels.rules
+install: edumail nymutt mutt .muttrc.nytid labels.rules
 	install -m 755 edumail nymutt mutt ${PREFIX}/bin
-	install -m 644 .muttrc.nymutt ${HOME}/.muttrc.nymutt
+	install -m 644 .muttrc.nytid ${HOME}/.muttrc.nytid
 	mkdir -p ${HOME}/.config/edumail
 	[ -e ${HOME}/.config/edumail/labels.rules ] \
 	  || install -m 644 labels.rules ${HOME}/.config/edumail/labels.rules

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: edumail.pdf muttnytid.pdf
+all: edumail.pdf nymutt.pdf
 
 LATEXFLAGS+=	-shell-escape
 
@@ -9,28 +9,28 @@ edumail.pdf: edumail
 
 edumail.tex: edumail.nw noweb_lexer.py
 
-muttnytid.pdf: muttnytid.tex didactic.sty
-muttnytid.pdf: preamble.tex
-muttnytid.pdf: mutt-nytid edumail .muttrc.nytid
+nymutt.pdf: nymutt.tex didactic.sty
+nymutt.pdf: preamble.tex
+nymutt.pdf: nymutt edumail .muttrc.nymutt
 
-muttnytid.tex: muttnytid.nw noweb_lexer.py
+nymutt.tex: nymutt.nw noweb_lexer.py
 
 
 .PHONY:
-all: edumail mutt-nytid mutt .muttrc.nytid labels.rules
+all: edumail nymutt mutt .muttrc.nymutt labels.rules
 
 edumail.sh: edumail.nw
 edumail: edumail.sh
 	cp $^ $@
 	chmod +x $@
 
-mutt-nytid.sh mutt.sh: muttnytid.nw
+nymutt.sh mutt.sh: nymutt.nw
 	${NOTANGLE.sh}
 
-.muttrc.nytid labels.rules: muttnytid.nw
+.muttrc.nymutt labels.rules: nymutt.nw
 	${NOTANGLE.sh}
 
-mutt-nytid: mutt-nytid.sh
+nymutt: nymutt.sh
 	cp $^ $@
 	chmod +x $@
 
@@ -42,15 +42,15 @@ mutt: mutt.sh
 .PHONY: clean
 clean:
 	${RM} edumail edumail.sh edumail.pdf edumail.tex
-	${RM} mutt-nytid mutt-nytid.sh mutt mutt.sh
-	${RM} .muttrc.nytid labels.rules muttnytid.pdf muttnytid.tex
+	${RM} nymutt nymutt.sh mutt mutt.sh
+	${RM} .muttrc.nymutt labels.rules nymutt.pdf nymutt.tex
 
 
 .PHONY: install
 PREFIX=${HOME}
-install: edumail mutt-nytid mutt .muttrc.nytid labels.rules
-	install -m 755 edumail mutt-nytid mutt ${PREFIX}/bin
-	install -m 644 .muttrc.nytid ${HOME}/.muttrc.nytid
+install: edumail nymutt mutt .muttrc.nymutt labels.rules
+	install -m 755 edumail nymutt mutt ${PREFIX}/bin
+	install -m 644 .muttrc.nymutt ${HOME}/.muttrc.nymutt
 	mkdir -p ${HOME}/.config/edumail
 	[ -e ${HOME}/.config/edumail/labels.rules ] \
 	  || install -m 644 labels.rules ${HOME}/.config/edumail/labels.rules

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: edumail.pdf
+all: edumail.pdf muttnytid.pdf
 
 LATEXFLAGS+=	-shell-escape
 
@@ -9,12 +9,32 @@ edumail.pdf: edumail
 
 edumail.tex: edumail.nw noweb_lexer.py
 
+muttnytid.pdf: muttnytid.tex didactic.sty
+muttnytid.pdf: preamble.tex
+muttnytid.pdf: mutt-nytid edumail .muttrc.nytid
+
+muttnytid.tex: muttnytid.nw noweb_lexer.py
+
 
 .PHONY:
-all: edumail
+all: edumail mutt-nytid mutt .muttrc.nytid labels.rules
 
 edumail.sh: edumail.nw
 edumail: edumail.sh
+	cp $^ $@
+	chmod +x $@
+
+mutt-nytid.sh mutt.sh: muttnytid.nw
+	${NOTANGLE.sh}
+
+.muttrc.nytid labels.rules: muttnytid.nw
+	${NOTANGLE.sh}
+
+mutt-nytid: mutt-nytid.sh
+	cp $^ $@
+	chmod +x $@
+
+mutt: mutt.sh
 	cp $^ $@
 	chmod +x $@
 
@@ -22,12 +42,18 @@ edumail: edumail.sh
 .PHONY: clean
 clean:
 	${RM} edumail edumail.sh edumail.pdf edumail.tex
+	${RM} mutt-nytid mutt-nytid.sh mutt mutt.sh
+	${RM} .muttrc.nytid labels.rules muttnytid.pdf muttnytid.tex
 
 
 .PHONY: install
 PREFIX=${HOME}
-install: edumail
-	install -m 755 $^ ${PREFIX}/bin
+install: edumail mutt-nytid mutt .muttrc.nytid labels.rules
+	install -m 755 edumail mutt-nytid mutt ${PREFIX}/bin
+	install -m 644 .muttrc.nytid ${HOME}/.muttrc.nytid
+	mkdir -p ${HOME}/.config/edumail
+	[ -e ${HOME}/.config/edumail/labels.rules ] \
+	  || install -m 644 labels.rules ${HOME}/.config/edumail/labels.rules
 
 .PHONY: release
 release: edumail.pdf edumail

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 all: edumail.pdf nymutt.pdf
 
 LATEXFLAGS+=	-shell-escape
+TEX_PYTHONTEX=	yes
 
 edumail.pdf: edumail.tex didactic.sty
 edumail.pdf: abstract.tex preamble.tex

--- a/edumail.nw
+++ b/edumail.nw
@@ -471,11 +471,50 @@ The [[course]] function calls [[course_code]] and [[course_nick]] to extract
 the course code and course nick name, respectively.
 Their outputs are just concatenated.
 
+Both functions rely on the same knowledge of which keywords indicate which 
+course; they differ only in what they print for it, a code or a nick name.
+So we keep that knowledge in one place, [[course_families]], and let both 
+derive their output from it.
+It prints one \emph{family} per line:
+the courses that share keywords, and that we therefore cannot tell apart from 
+the text of an email---[[prgm]] (DD1310) and [[prgi]] (DD1317) being the 
+typical pair.
+Members are named by nick name, the shorter and more stable of the two names.
+<<functions>>=
+course_families() {
+  local file=$(file_or_stdin "$1")
+  if <<test for datintro terms>>; then
+    echo "datintro progd"
+  fi
+  if <<test for programming terms>>; then
+    echo "prgm prgi"
+  fi
+  if <<test for crypto terms>>; then
+    echo "tilkry"
+  fi
+  if <<test for science terms>>; then
+    echo "vetcyb"
+  fi
+}
+@ Note that we don't use [[elif]]: a student might write about several courses 
+in one email.
+
+The course code of each nick name is a table.
+<<variables>>=
+declare -A COURSE_CODES=(
+  [datintro]=DD1301 [progd]=DD1337
+  [prgm]=DD1310     [prgi]=DD1317
+  [tilkry]=DD2520
+  [vetcyb]=DA2215
+)
+@
+
 The [[course_code]] function will look for the course code in the email.
 If it finds something that looks like a course code, it will return it 
 (printing it to stdout).
-Then it will look for keywords in the email that indicate which course it is, 
-then output the course code for that course.
+Then it adds the codes of every course whose keywords occur in the email; 
+the unquoted [[$(course_families ...)]] splits the families into their 
+members.
 Since many might match, we sort the output and remove duplicates.
 Finally, we make a disjunct regex from the output.
 <<functions>>=
@@ -484,20 +523,9 @@ course_code() {
   (
     clean "$file" \
     | grep -Po "${COURSE_CODE}"
-    if <<test for datintro terms>>; then
-      echo "DD1301"
-      echo "DD1337"
-    fi
-    if <<test for programming terms>>; then
-      echo "DD1310"
-      echo "DD1317"
-    fi
-    if <<test for crypto terms>>; then
-      echo "DD2520"
-    fi
-    if <<test for science terms>>; then
-      echo "DA2215"
-    fi
+    for nick in $(course_families "$file"); do
+      echo "${COURSE_CODES[$nick]}"
+    done
   ) | sort -u \
     | make_disjunct_regex
 }
@@ -517,26 +545,17 @@ print_verbatim(output.stdout)
 
 The [[course_nick]] function will do exactly the same, but look for the course 
 nick name in the email and output a nickname instead.
+A nick name found by keywords gets the recent-years suffix, since we're 
+guessing the course round the student means (see above).
 <<functions>>=
 course_nick() {
   local file=$(file_or_stdin "$1")
   (
     clean "$file" \
     | grep -Po "${COURSE_NICK}"
-    if <<test for datintro terms>>; then
-      echo "datintro${YEARS_REGEX}"
-      echo "progd${YEARS_REGEX}"
-    fi
-    if <<test for programming terms>>; then
-      echo "prgm${YEARS_REGEX}"
-      echo "prgi${YEARS_REGEX}"
-    fi
-    if <<test for crypto terms>>; then
-      echo "tilkry${YEARS_REGEX}"
-    fi
-    if <<test for science terms>>; then
-      echo "vetcyb${YEARS_REGEX}"
-    fi
+    for nick in $(course_families "$file"); do
+      echo "${nick}${YEARS_REGEX}"
+    done
   ) | sort -u \
     | make_disjunct_regex
 }
@@ -713,7 +732,11 @@ in the email.
 We note that we must not match the course code, since those also fit the 
 pattern in [[ASSIGNMENT_GROUP]], so we remove anything that also match a course 
 code.
+The keyword tests below are course specific, so we also determine the course 
+here---once, since [[course]] is the expensive part of this script and the 
+tests below would otherwise each run it again.
 <<find assignment groups in [[file]]>>=
+local courses=$(course "$file")
 clean "$file" \
 | grep -Po "${ASSIGNMENT_GROUP}" \
 | grep -Pv "${COURSE_CODE}"
@@ -726,12 +749,12 @@ group, so we can reuse the tests from above.
 However, a keyword in one course might indicate a different assignment group in 
 another course, so we'd better make these course specific.
 <<find assignment groups in [[file]]>>=
-if course "$file" | grep -qP "(DD13(01|37)|datintro)"; then
+if grep -qP "(DD13(01|37)|datintro)" <<< "${courses}"; then
   if <<test for datintro terms>>; then
     echo "LAB1"
   fi
 fi
-if course "$file" | grep -qP "(DA2215|vetcyb)"; then
+if grep -qP "(DA2215|vetcyb)" <<< "${courses}"; then
   if <<test for science terms>>; then
     echo "INL1"
   fi
@@ -742,7 +765,7 @@ in one email.
 For the other courses we must be more specific, since they have different 
 modules corresponding to different assignments.
 <<find assignment groups in [[file]]>>=
-if course "$file" | grep -qP "(DD131[07]|prg[im])"; then
+if grep -qP "(DD131[07]|prg[im])" <<< "${courses}"; then
   if <<test for programming LAB1 terms>>; then
     echo "LAB1"
   fi
@@ -756,7 +779,7 @@ if course "$file" | grep -qP "(DD131[07]|prg[im])"; then
     echo "KAL1"
   fi
 fi
-if course "$file" | grep -qP "(DD2520|tilkry)"; then
+if grep -qP "(DD2520|tilkry)" <<< "${courses}"; then
   if <<test for tilkry LAB1 terms>>; then
     echo "LAB1"
   fi
@@ -1206,32 +1229,46 @@ Where the results subcommands output regexes---they need to \emph{match}
 course rounds like [[prgi23]]---time tracking needs stable \emph{names}.
 A label is an identity that accumulates time across years, so we output
 the course nick without any year suffix ([[tilkry]], not
-[[tilkry(24|25|26)]]).
-For the same reason we output one label per course family rather than the
-code pairs the results subcommands use:
-[[prgm]] covers both DD1310 and DD1317, whose emails we cannot tell apart
-anyway.
-Course codes that appear \emph{literally} in the email are still worth
-emitting: the student told us exactly which course they mean, and a code
-is a stable name.
+[[tilkry(24|25|26)]]), and we strip the year from a nick the student
+wrote ([[prgi23]] becomes [[prgi]]).
+We also prefer the nick to the code even when the student wrote the code:
+[[prgi]] rather than [[DD1317]], so that the time lands under the one
+name we use for the course everywhere else in [[nytid]].
+That translation is the [[COURSE_CODES]] table read backwards; a code the
+table doesn't know is a stable name in its own right and passes through
+unchanged (a user's rules file can then map it, see below).
+<<functions>>=
+nick_of_course_code() {
+  local code="${1^^}" nick
+  for nick in "${!COURSE_CODES[@]}"; do
+    if [[ "${COURSE_CODES[$nick]}" == "${code}" ]]; then
+      echo "${nick}"
+      return
+    fi
+  done
+  echo "${code}"
+}
+@
+
+The families pose a choice.
+When only keywords identify the course, we cannot tell [[prgm]] from
+[[prgi]] and we output both; the concurrent-label model makes that cheap,
+and the sum for either course is still right---and old students of
+[[prgm]] do still write.
+But when the email names a member of the family by code, we output only
+that member:
+a student who writes DD1317 has told us which course they mean, and a
+[[prgm]] label would only be noise.
+Assignment groups are labels too---[[INL1]] and [[LAB2]] are what we
+already track by hand---so we reuse the search from [[assignment_groups]],
+but not the default it falls back on:
+a label must name something the email actually mentions.
 <<functions>>=
 labels() {
   local file=$(file_or_stdin "$1")
   (
-    clean "$file" \
-    | grep -Po "${COURSE_CODE}"
-    if <<test for datintro terms>>; then
-      echo "datintro"
-    fi
-    if <<test for programming terms>>; then
-      echo "prgm"
-    fi
-    if <<test for crypto terms>>; then
-      echo "tilkry"
-    fi
-    if <<test for science terms>>; then
-      echo "vetcyb"
-    fi
+    <<emit one label per course>>
+    <<find assignment groups in [[file]]>>
     labels_rules "$file"
   ) | sort -u
 }
@@ -1240,6 +1277,30 @@ or several rules yielding the same label---so we deduplicate, and the
 sorted output doubles as a canonical form that callers can compare and
 diff against (which [[nymutt]] does to keep timers running across
 consecutive emails about the same course).
+
+The course labels come from three places:
+the families whose keywords match, narrowed by any codes in the email;
+the codes themselves, translated; and the nicks the student wrote, with
+the year removed.
+The [[grep -x]] against the (upper-cased) code list is how a family
+member counts as named; [[${named:-${family}}]] then falls back to the
+whole family when no member was.
+<<emit one label per course>>=
+local codes=$(clean "$file" | grep -Po "${COURSE_CODE}" \
+              | tr '[:lower:]' '[:upper:]' | sort -u)
+local family named nick code
+while read -r family; do
+  named=""
+  for nick in ${family}; do
+    grep -qx "${COURSE_CODES[$nick]}" <<< "${codes}" && named+=" ${nick}"
+  done
+  printf '%s\n' ${named:-${family}}
+done < <(course_families "$file")
+for code in ${codes}; do
+  nick_of_course_code "${code}"
+done
+clean "$file" | grep -Po "${COURSE_NICK}" | sed -E 's/[0-9]{2}$//'
+@
 
 \subsection{User-defined label rules}
 
@@ -1328,8 +1389,8 @@ esac | grep -qiP "${pattern}" \
 Let's run [[labels]] on the example emails.
 (We point [[XDG_CONFIG_HOME]] at a nonexistent directory so the author's
 personal rules file doesn't leak into this document.)
-\Cref{email1} mentions the programming course by code and by keywords, so
-it yields:
+\Cref{email1} mentions the programming course by code (DD1317) and by
+keywords, so the family collapses to the one course named:
 \begin{pycode}
 import os
 norules = dict(os.environ, XDG_CONFIG_HOME="/nonexistent")
@@ -1339,7 +1400,7 @@ print_verbatim(output.stdout)
 \end{pycode}
 \Cref{email2} never names a course, but its subject
 (\enquote{Projektgranskning}) hits the programming courses' keyword test,
-so the email is still labelled:
+so the email gets the whole family---and the project's assignment group:
 \begin{pycode}
 output = subprocess.run(["./edumail", "labels", "email2.txt"],
                         capture_output=True, env=norules)

--- a/edumail.nw
+++ b/edumail.nw
@@ -1023,6 +1023,7 @@ So we output one pipeline per form instead.
 That's also more convenient when we want to edit the commands in the editor: 
 the form name is right there in the command, rather than hidden in a variable.
 <<construct [[restlabb]] command from email>>=
+<<fetch forms data if not already done>>
 for form in ${RESTLABB_FORMS}; do
   echo "kthutils forms export ${form} \\"
   echo '  | <<resort chronologically>> \'
@@ -1039,11 +1040,28 @@ header row of the export.
 Let's define the variables we need for handling restlabb.
 We can simply look through all the forms that we have.
 At least those that match \enquote{restlabb} and \enquote{labweek}.
-Since [[kthutils forms ls]] lists the forms oldest first, we'll process the 
+Since [[kthutils forms ls]] lists the forms oldest first, we'll process the
 forms in chronological order.
-<<variables>>=
-RESTLABB_FORMS=$(kthutils forms ls \
-                 | grep -iE "restlabb2[5-9]/2[6-9]|labweek202[6-9]")
+
+We don't want to fetch this data when the script loads.
+Each [[kthutils]] call is a round trip to KTH's servers, taking seconds.
+That was acceptable when the script was only used for the results
+subcommands, which need the data anyway.
+But the [[labels]] subcommand (\cref{LabelsSection}) is called for every
+email we open in [[mutt]], and it never needs the forms.
+So we fetch the data at first use instead, using the same flag-variable
+idiom as [[<<output variables if not already done>>]].
+The memoization works across the [[$(form_rewriter ...)]] command
+substitutions in [[<<construct [[restlabb]] command from email>>]]:
+the fetch runs in the function's own shell, so the subshells inherit both
+the flag and the fetched variables.
+<<fetch forms data if not already done>>=
+if [[ -z "$FORMS_ALREADY_FETCHED" ]]; then
+  FORMS_ALREADY_FETCHED=1
+  RESTLABB_FORMS=$(kthutils forms ls \
+                   | grep -iE "restlabb2[5-9]/2[6-9]|labweek202[6-9]")
+  <<fetch the [[REWRITERS]] from the [[kthutils]] config>>
+fi
 @
 
 Within a form, the newest entry is first.
@@ -1078,6 +1096,7 @@ by a shared one.
 <<functions>>=
 form_rewriter() {
   local form="$1"
+  <<fetch forms data if not already done>>
   if echo "${REWRITERS}" | grep -qxF "${form}"; then
     echo "${form}"
   else
@@ -1086,13 +1105,18 @@ form_rewriter() {
 }
 @
 
-To know which rewriters exist, we list the config keys under 
+Note that [[form_rewriter]] also starts with
+[[<<fetch forms data if not already done>>]]:
+it needs [[REWRITERS]] when called directly as a subcommand, without going
+through [[restlabb]] first.
+
+To know which rewriters exist, we list the config keys under
 [[forms.rewriter]].
-Each rewriter has several settings, so the same name appears several times and 
+Each rewriter has several settings, so the same name appears several times and
 we must remove duplicates.
-The rewriter name can contain a slash (\eg [[restlabb26/27]]) but never a dot, 
+The rewriter name can contain a slash (\eg [[restlabb26/27]]) but never a dot,
 which is the separator in the config path.
-<<variables>>=
+<<fetch the [[REWRITERS]] from the [[kthutils]] config>>=
 REWRITERS=$(kthutils config forms.rewriter \
             | sed -En "s/^forms\.rewriter\.([^.]+)\..*/\1/p" | sort -u)
 @
@@ -1163,6 +1187,167 @@ output = subprocess.run(["./edumail", "results", "email3.txt"],
                         capture_output=True)
 print_verbatim(str(output.stdout, "utf-8"))
 \end{pycode}
+
+
+\section{Extracting time-tracking labels}\label{LabelsSection}
+
+The same parsing that finds a course for the results subcommands can also
+answer a different question: which time-tracking labels does this email
+belong to?
+We track our working time with [[nytid track]], which tracks any number of
+concurrently running, free-form labels.
+The [[mutt-nytid]] integration (its own literate program,
+[[muttnytid.nw]], in this repository) starts labels when we open an email
+in [[mutt]] and stops them when we return to the index.
+It delegates the parsing to the [[labels]] subcommand, so that all
+knowledge about what our emails look like stays in one place.
+
+Where the results subcommands output regexes---they need to \emph{match}
+course rounds like [[prgi23]]---time tracking needs stable \emph{names}.
+A label is an identity that accumulates time across years, so we output
+the course nick without any year suffix ([[tilkry]], not
+[[tilkry(24|25|26)]]).
+For the same reason we output one label per course family rather than the
+code pairs the results subcommands use:
+[[prgm]] covers both DD1310 and DD1317, whose emails we cannot tell apart
+anyway.
+Course codes that appear \emph{literally} in the email are still worth
+emitting: the student told us exactly which course they mean, and a code
+is a stable name.
+<<functions>>=
+labels() {
+  local file=$(file_or_stdin "$1")
+  (
+    clean "$file" \
+    | grep -Po "${COURSE_CODE}"
+    if <<test for datintro terms>>; then
+      echo "datintro"
+    fi
+    if <<test for programming terms>>; then
+      echo "prgm"
+    fi
+    if <<test for crypto terms>>; then
+      echo "tilkry"
+    fi
+    if <<test for science terms>>; then
+      echo "vetcyb"
+    fi
+    labels_rules "$file"
+  ) | sort -u
+}
+@ Duplicates are expected---a course both named and described by keywords,
+or several rules yielding the same label---so we deduplicate, and the
+sorted output doubles as a canonical form that callers can compare and
+diff against (which [[mutt-nytid]] does to keep timers running across
+consecutive emails about the same course).
+
+\subsection{User-defined label rules}
+
+The course tests above change rarely, so hard-coding them in this script
+is fine.
+Label rules are different: a new mailing list, an administrative sender, a
+committee---these appear all the time, and the person adding them is in
+their mail client, not in this repository rebuilding the script.
+So the remaining rules live in a configuration file,
+<<variables>>=
+LABELS_RULES="${XDG_CONFIG_HOME:-$HOME/.config}/edumail/labels.rules"
+@ with one rule per line:
+a pattern, whitespace, and the labels that pattern maps to.
+A [[#]] starts a comment.
+The pattern is a case-insensitive Perl regex, optionally prefixed by a
+field to restrict where it must match:
+[[from:]] matches only the \enquote{From: } header (this is how senders
+become labels), [[subject:]] only the \enquote{Subject: } header, and no
+prefix matches anywhere in the cleaned email.
+For example:
+\begin{minted}{text}
+# pattern                      labels
+from:.*@ug\.kth\.se            admin
+exjobb|thesis                  supervision exjobb
+\end{minted}
+
+We read the file with [[read]], which splits on whitespace:
+the first word is the pattern, the rest are the labels.
+This gives a trivially simple format at the price that a pattern cannot
+contain literal whitespace---use [[\s]] in the regex instead.
+Every matching rule contributes its labels; an email about two things gets
+both sets, which is exactly what concurrent time tracking wants.
+<<functions>>=
+labels_rules() {
+  local file=$(file_or_stdin "$1")
+  [[ -r "${LABELS_RULES}" ]] || return 0
+  local pattern rule_labels field
+  while read -r pattern rule_labels; do
+    <<skip comments and blank lines>>
+    <<split any [[field]] prefix off [[pattern]]>>
+    <<emit [[rule_labels]] if [[pattern]] matches [[field]]>>
+  done < "${LABELS_RULES}"
+}
+@ A missing rules file is not an error:
+the course tests alone are a useful default, and [[mutt-nytid]] must keep
+working on a machine where no rules have been written yet.
+
+A comment line's first word starts with [[#]], and on a blank line
+[[read]] leaves the pattern empty.
+<<skip comments and blank lines>>=
+[[ -z "${pattern}" || "${pattern}" == \#* ]] && continue
+@
+
+The field prefix is split off with shell prefix removal rather than
+parsed with a regex:
+a colon is legal in a regex, so we only treat the two known prefixes
+specially and let anything else---including a pattern that happens to
+start with [[http:]]---fall through as a whole-email pattern.
+<<split any [[field]] prefix off [[pattern]]>>=
+field=any
+case "${pattern}" in
+  from:*)    field=from;    pattern="${pattern#from:}";;
+  subject:*) field=subject; pattern="${pattern#subject:}";;
+esac
+@
+
+Matching selects the text to search and then reuses the same
+case-insensitive Perl grep as the course tests.
+The header fields are matched against the raw email, not the cleaned one:
+[[clean]] exists to stop \emph{body} keywords from matching noise headers,
+but a [[from:]] rule wants exactly a header line.
+The unquoted [[${rule_labels}]] in [[printf]] is deliberate:
+word splitting turns the rule's labels into one argument each, which
+[[printf]] then prints one per line, the output format of [[labels]].
+<<emit [[rule_labels]] if [[pattern]] matches [[field]]>>=
+case "${field}" in
+  from)    grep -i "^From: "    "$file";;
+  subject) grep -i "^Subject: " "$file";;
+  any)     clean "$file";;
+esac | grep -qiP "${pattern}" \
+  && printf '%s\n' ${rule_labels}
+@
+
+\subsection{Testing on the emails}
+
+Let's run [[labels]] on the example emails.
+(We point [[XDG_CONFIG_HOME]] at a nonexistent directory so the author's
+personal rules file doesn't leak into this document.)
+\Cref{email1} mentions the programming course by code and by keywords, so
+it yields:
+\begin{pycode}
+import os
+norules = dict(os.environ, XDG_CONFIG_HOME="/nonexistent")
+output = subprocess.run(["./edumail", "labels", "email1.txt"],
+                        capture_output=True, env=norules)
+print_verbatim(output.stdout)
+\end{pycode}
+\Cref{email2} never names a course, but its subject
+(\enquote{Projektgranskning}) hits the programming courses' keyword test,
+so the email is still labelled:
+\begin{pycode}
+output = subprocess.run(["./edumail", "labels", "email2.txt"],
+                        capture_output=True, env=norules)
+print_verbatim(output.stdout)
+\end{pycode}
+An email matching neither a course test nor a rule yields nothing at all;
+it's the caller's job to fall back to something sensible---[[mutt-nytid]]
+always adds a base [[email]] label of its own.
 
 
 \section{The script as a whole}

--- a/edumail.nw
+++ b/edumail.nw
@@ -1196,8 +1196,8 @@ answer a different question: which time-tracking labels does this email
 belong to?
 We track our working time with [[nytid track]], which tracks any number of
 concurrently running, free-form labels.
-The [[mutt-nytid]] integration (its own literate program,
-[[muttnytid.nw]], in this repository) starts labels when we open an email
+The [[nymutt]] integration (its own literate program,
+[[nymutt.nw]], in this repository) starts labels when we open an email
 in [[mutt]] and stops them when we return to the index.
 It delegates the parsing to the [[labels]] subcommand, so that all
 knowledge about what our emails look like stays in one place.
@@ -1238,7 +1238,7 @@ labels() {
 @ Duplicates are expected---a course both named and described by keywords,
 or several rules yielding the same label---so we deduplicate, and the
 sorted output doubles as a canonical form that callers can compare and
-diff against (which [[mutt-nytid]] does to keep timers running across
+diff against (which [[nymutt]] does to keep timers running across
 consecutive emails about the same course).
 
 \subsection{User-defined label rules}
@@ -1284,7 +1284,7 @@ labels_rules() {
   done < "${LABELS_RULES}"
 }
 @ A missing rules file is not an error:
-the course tests alone are a useful default, and [[mutt-nytid]] must keep
+the course tests alone are a useful default, and [[nymutt]] must keep
 working on a machine where no rules have been written yet.
 
 A comment line's first word starts with [[#]], and on a blank line
@@ -1346,7 +1346,7 @@ output = subprocess.run(["./edumail", "labels", "email2.txt"],
 print_verbatim(output.stdout)
 \end{pycode}
 An email matching neither a course test nor a rule yields nothing at all;
-it's the caller's job to fall back to something sensible---[[mutt-nytid]]
+it's the caller's job to fall back to something sensible---[[nymutt]]
 always adds a base [[email]] label of its own.
 
 

--- a/muttnytid.nw
+++ b/muttnytid.nw
@@ -431,14 +431,20 @@ cleanup() {
 The [[mutt]] side is a handful of macros.
 All syntax below is understood by both [[mutt]] and [[neomutt]].
 
-First two settings.
+First three settings.
 [[wait_key]] would otherwise pause with \enquote{Press any key to
 continue} after every [[<shell-escape>]]/[[<pipe-message>]], turning
 each opened email into two keypresses; our commands are silent on
 success, so nothing useful is lost.
+[[pager_stop]] closes a tracking hole:
+without it, pressing space ([[<next-page>]]) at the end of a message
+silently advances to the next message, bypassing every macro below.
+With it, space stops at the end and moving on is always an explicit
+key we \emph{have} wrapped.
 The [[editor]] is the wrapper from \cref{EditorWrapper}.
 <<[[.muttrc.nytid]]>>=
 set wait_key = no
+set pager_stop = yes
 set editor = "~/bin/mutt-nytid editor"
 @
 
@@ -447,6 +453,13 @@ pipe the message to [[open]], then display it.
 [[<pipe-message>]] respects [[pipe_decode]] (set in our [[~/.muttrc]]),
 so the script sees a decoded body---better for keyword matching than
 raw quoted-printable---while the headers it needs are kept.
+We must cover \emph{every} key that displays a message from the index.
+By default [[<display-message>]] sits on return, enter, keypad-enter
+and space, and [[h]] ([[<display-toggle-weed>]]) also opens the
+message, just with full headers.
+Keys that merely move the index selection---tab
+([[<next-new-then-unread>]]), [[j]]/[[k]], arrows---need no wrapping:
+no message is displayed, so no tracking should start.
 <<[[.muttrc.nytid]]>>=
 macro index <return> \
   "<pipe-message>~/bin/mutt-nytid open<enter><display-message>" \
@@ -454,8 +467,17 @@ macro index <return> \
 macro index <enter> \
   "<pipe-message>~/bin/mutt-nytid open<enter><display-message>" \
   "track and read message"
-@ Both [[<return>]] and [[<enter>]] are bound, since terminals differ
-in which of the two the return key produces.
+macro index <keypadenter> \
+  "<pipe-message>~/bin/mutt-nytid open<enter><display-message>" \
+  "track and read message"
+macro index <space> \
+  "<pipe-message>~/bin/mutt-nytid open<enter><display-message>" \
+  "track and read message"
+macro index h \
+  "<pipe-message>~/bin/mutt-nytid open<enter><display-toggle-weed>" \
+  "track and read message with full headers"
+@ ([[<keypadenter>]] is a NeoMutt key name; delete that line if this
+file ever feeds a stock mutt.)
 
 Leaving the pager for the index:
 <<[[.muttrc.nytid]]>>=
@@ -466,22 +488,73 @@ macro pager q "<shell-escape>~/bin/mutt-nytid close<enter><exit>" \
 @
 
 Moving between messages without leaving the pager bypasses the index
-bindings, so the navigation keys retarget the tracking themselves.
+bindings, so every message-switching pager key retargets the tracking
+itself.
 No [[close]] is needed: [[open]]'s set-difference reconciliation
 \emph{is} the close for whatever the previous message no longer
 justifies.
+And the pattern is harmless when the move fails (last message, no new
+mail): the pipe then re-feeds the \emph{same} message, whose derived
+set matches what we own, so [[open]] does nothing.
+
+The pager defaults offer many switching keys:
+[[J]]/[[K]] ([[<next-entry>]]/[[<previous-entry>]]),
+tab ([[<next-new-then-unread>]]---the workhorse when reading new
+mail),
+[[j]]/[[k]] and the arrows
+([[<next-undeleted>]]/[[<previous-undeleted>]]),
+and the thread motions on control-N/P and escape-n/p.
+We wrap them all with the same tail.
 <<[[.muttrc.nytid]]>>=
 macro pager J "<next-entry><pipe-message>~/bin/mutt-nytid open<enter>" \
   "track and view next message"
 macro pager K \
   "<previous-entry><pipe-message>~/bin/mutt-nytid open<enter>" \
   "track and view previous message"
-@ A known leak remains:
-anything else that auto-advances the pager (deleting with [[d]] when
-[[resolve]] is set, for instance) keeps the previous email's labels
-running until the next [[open]] or [[close]].
-We accept that rather than wrapping every such key; wrap [[d]] the same
-way as [[J]] if it turns out to matter.
+macro pager <tab> \
+  "<next-new-then-unread><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "track and view next new message"
+macro pager j \
+  "<next-undeleted><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "track and view next undeleted message"
+macro pager <down> \
+  "<next-undeleted><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "track and view next undeleted message"
+macro pager <right> \
+  "<next-undeleted><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "track and view next undeleted message"
+macro pager k \
+  "<previous-undeleted><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "track and view previous undeleted message"
+macro pager <up> \
+  "<previous-undeleted><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "track and view previous undeleted message"
+macro pager <left> \
+  "<previous-undeleted><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "track and view previous undeleted message"
+macro pager \Cn \
+  "<next-thread><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "track and view next thread"
+macro pager \Cp \
+  "<previous-thread><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "track and view previous thread"
+macro pager \en \
+  "<next-subthread><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "track and view next subthread"
+macro pager \ep \
+  "<previous-subthread><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "track and view previous subthread"
+@ One known leak remains:
+deleting with [[d]] auto-advances the pager (via [[resolve]]) without
+retargeting, so the deleted email's labels run until the next wrapped
+key or [[close]].
+We leave [[d]] unwrapped on purpose:
+after deleting the \emph{last} message the pager falls back to the
+index, where a trailing [[<pipe-message>]] would start labels for a
+message we are not reading---a worse failure than a short-lived stale
+label that the next tab press corrects anyway.
+(Pager [[h]] needs no wrapping either: it redisplays the \emph{same}
+message with full headers, and the labels are already running.)
 
 Finally, adjusting the labels while reading (or from the index):
 <<[[.muttrc.nytid]]>>=

--- a/muttnytid.nw
+++ b/muttnytid.nw
@@ -1,0 +1,548 @@
+\documentclass[a4paper,10pt,article,oneside,oldfontcommands]{memoir}
+\let\subsubsection\subsection
+\let\subsection\section
+\let\section\chapter
+
+\input{preamble.tex}
+\noweboptions{longxref,breakcode}
+
+\usepackage[noamsthm,notheorems]{beamerarticle}
+\setjobnamebeamerversion{slides}
+
+\title{%
+  Tracking email time in mutt with nytid
+}
+\author{%
+  Daniel Bosk
+}
+\institute{%
+  KTH EECS
+}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+  We track our working time with [[nytid track]], which can run any
+  number of concurrently running, free-form labels.
+  We want that tracking to be automatic while reading email:
+  when we open an email in [[mutt]], labels derived from the email
+  (course, sender, keywords) should start; when we return to the index,
+  they should stop; while we write a reply, a [[replying]] label should
+  run.
+  [[mutt]] has no hooks for leaving the pager or finishing a reply, so we
+  build the integration from macro-wrapped key bindings, an editor
+  wrapper, and a small state-keeping helper script.
+  The label derivation itself is [[edumail]]'s job (its [[labels]]
+  subcommand); this document only glues it to [[mutt]] and [[nytid]].
+\end{abstract}
+\vfill
+\inputminted[numbers=none]{text}{LICENSE}
+\clearpage
+
+\tableofcontents
+\clearpage
+
+\begin{pycode}
+import os
+import subprocess
+
+def print_verbatim(output):
+    print(r"\begin{verbatim}")
+    if isinstance(output, bytes):
+      output = output.decode()
+    print(output)
+    print(r"\end{verbatim}")
+
+demoenv = dict(os.environ,
+               EDUMAIL="./edumail",
+               XDG_CONFIG_HOME="/nonexistent")
+\end{pycode}
+
+@
+\section{Introduction}
+
+% What's the problem?
+We already track the [[mutt]] session as a whole:
+the [[mutt]] command on our machines is a wrapper that runs
+\mintinline{bash}{nytid track start mutt -- neomutt}, so the [[mutt]]
+label runs for as long as the mail client does.
+That tells us how much time email costs in total, but not \emph{what}
+the time was spent on---which course, which committee, which student
+matter when we sum up hours.
+% What's the approach?
+Since [[edumail labels]] can already tell from an email which labels it
+belongs to, the missing piece is knowing \emph{when} we start and stop
+reading each email.
+
+The natural place for that knowledge is [[mutt]] itself, but [[mutt]]'s
+hook model works against us.
+There are hooks that fire before a message is displayed
+([[message-hook]]) and before a message is sent ([[send-hook]]), but
+there is no hook for returning from the pager to the index, and none
+for finishing (or aborting) a reply.
+So instead of hooks we use macros:
+we rebind the keys that open, leave, and navigate between messages so
+that they additionally pipe the message through a helper script.
+For replies we use a different trick, described in
+\cref{EditorWrapper}, that needs no reply bindings at all.
+
+\subsection{Structural overview}
+
+This document tangles four files that cooperate:
+\begin{description}
+\item[\normalfont [[<<[[mutt-nytid.sh]]>>]] ]
+  installed as [[~/bin/mutt-nytid]]:
+  the helper script that [[mutt]] calls.
+  It derives labels (via [[edumail labels]]), starts and stops
+  [[nytid]] timers, and keeps state about which labels \emph{it}
+  started.
+\item[\normalfont [[<<[[.muttrc.nytid]]>>]] ]
+  installed as [[~/.muttrc.nytid]] and sourced from [[~/.muttrc]]:
+  the macros and settings that wire the helper into [[mutt]].
+\item[\normalfont [[<<[[mutt.sh]]>>]] ]
+  installed as [[~/bin/mutt]]:
+  the session wrapper, extended to clean up per-email timers when the
+  mail client exits.
+\item[\normalfont [[<<[[labels.rules]]>>]] ]
+  installed as [[~/.config/edumail/labels.rules]] (only if absent):
+  seed rules for [[edumail labels]], see the edumail documentation for
+  the format.
+\end{description}
+
+A reading session then works like this.
+Pressing return in the index pipes the message to
+[[mutt-nytid open]], which starts the derived labels, and then displays
+the message.
+Leaving the pager runs [[mutt-nytid close]], which stops them.
+Moving to the next message from within the pager runs [[open]] again,
+which retargets the timers:
+labels shared with the previous email simply keep running.
+Replying opens the editor, which [[mutt]] is configured to reach
+through [[mutt-nytid editor]]---the wrapper tracks the [[replying]]
+label for exactly as long as the editor runs.
+And when the mail client exits, the [[mutt]] wrapper calls
+[[mutt-nytid cleanup]] so no per-email timer can outlive the session.
+
+
+\section{The helper script}\label{TheHelperScript}
+
+The script follows the same conventions as [[edumail]]:
+subcommands are functions, dispatched by a [[main]] that is skipped
+when the script is sourced, and functions that read a message accept a
+filename or fall back to stdin.
+<<[[mutt-nytid.sh]]>>=
+#!/bin/bash
+
+<<variables>>
+<<functions>>
+
+main() {
+  <<parse which subcommand should be called and call its function>>
+}
+
+# call main if not sourced
+# https://stackoverflow.com/a/28776166/1305099
+(return 0 2>/dev/null) || main "$@"
+@
+
+The dispatcher is the same construction as in [[edumail]]:
+evaluate [["$@"]] so the first argument names the function and the rest
+become its arguments, or print the list of functions as usage.
+<<parse which subcommand should be called and call its function>>=
+[[ "$1" = "" ]] \
+  && echo -e "Usage: $0 [function] args\nFunctions:\n$(
+       sed -En 's/^(\w+)\(\) \{/  \1/p' $0 | grep -Pv '^\s*main$')" \
+  || "$@"
+@
+
+We also need [[edumail]]'s [[file_or_stdin]]:
+[[mutt]]'s [[<pipe-message>]] gives us the message on stdin, but the
+functions may need to read it more than once.
+The [[EDUMAIL]] variable lets tests (and this document's compilation)
+point at a not-yet-installed [[edumail]].
+<<functions>>=
+file_or_stdin() {
+  local file="$1"
+  if [[ "$file" = "" ]]; then
+    file=$(mktemp)
+    cat > "$file"
+  fi
+  echo "$file"
+}
+<<variables>>=
+EDUMAIL="${EDUMAIL:-edumail}"
+@
+
+\subsection{State: the labels we own}
+
+The one invariant that makes this integration safe to run next to
+everything else [[nytid]] tracks is \emph{ownership}:
+the script only ever stops labels that it started itself.
+The outer [[mutt]] session label, timers started from another terminal,
+another concurrently running [[mutt]]---none of these may be touched.
+We therefore never use [[nytid track stop]]'s batch semantics (stop the
+most recent batch), which could hit someone else's batch; we always
+stop explicitly named labels, and only names taken from our own record.
+
+That record is a file, [[current]], holding one label per line, sorted.
+Sorted, because the functions below compare label sets with [[comm]],
+which requires sorted input; keeping the file sorted at every write
+means we never have to remember to sort at the reads.
+The file lives in a per-session directory:
+the [[mutt]] wrapper exports [[MUTT_NYTID_SESSION]] (its process id),
+so two mail clients running at the same time keep separate books.
+<<variables>>=
+STATE_DIR="${XDG_RUNTIME_DIR:-$HOME/.cache}/mutt-nytid"
+STATE_DIR="${STATE_DIR}/${MUTT_NYTID_SESSION:-default}"
+CURRENT="${STATE_DIR}/current"
+@
+
+Reading the record must work before the first [[open]] has created it,
+so a missing file just means we own nothing yet.
+<<functions>>=
+current_labels() {
+  [[ -r "${CURRENT}" ]] && cat "${CURRENT}"
+  return 0
+}
+@
+
+Starting labels is where ownership is established, so we don't record
+what we \emph{asked} for but what [[nytid]] \emph{confirms} it started.
+[[nytid track start]] is idempotent:
+labels already running are reported as \enquote{Already tracking} and
+left alone, and only the rest appear on the \enquote{Started tracking}
+line.
+Parsing that line is what protects the outer [[mutt]] label---if a
+derived label happens to already run for some other reason, it never
+enters our record and we will never stop it.
+(This also means labels must not contain spaces or commas, which
+[[nytid]]'s own command line syntax already imposes.)
+<<functions>>=
+start_labels() {
+  [[ $# -eq 0 ]] && return 0
+  mkdir -p "${STATE_DIR}"
+  local started
+  started=$(nytid track start "$@" \
+            | sed -n 's/^Started tracking: //p' \
+            | tr -d ' ' | tr ',' '\n')
+  (current_labels; echo "${started}") \
+    | sort -u | grep -v '^$' > "${CURRENT}.new"
+  mv "${CURRENT}.new" "${CURRENT}"
+}
+@ We consume [[nytid]]'s stdout (the parsing does), which has the nice
+side effect that the [[mutt]] macros run silently;
+errors still reach the terminal on stderr.
+
+Stopping is the mirror image:
+stop exactly the named labels, then drop them from the record.
+We drop them even if [[nytid]] complains---a label that isn't running
+anymore (say, stopped from another terminal) shouldn't stay in our
+books either.
+<<functions>>=
+stop_labels() {
+  [[ $# -eq 0 ]] && return 0
+  mkdir -p "${STATE_DIR}"
+  nytid track stop "$@" > /dev/null || true
+  comm -23 <(current_labels) <(printf '%s\n' "$@" | sort -u) \
+    > "${CURRENT}.new"
+  mv "${CURRENT}.new" "${CURRENT}"
+}
+@
+
+\subsection{Deriving labels}
+
+Derivation is [[edumail]]'s job; the script adds only the base
+[[email]] label, so that every opened email is tracked even when
+[[edumail]] recognizes nothing.
+The output is sorted and duplicate-free for the same reason [[current]]
+is: the callers compare label sets with [[comm]].
+<<functions>>=
+derive() {
+  local file=$(file_or_stdin "$1")
+  (
+    echo "email"
+    "${EDUMAIL}" labels "$file"
+  ) | sort -u
+}
+@
+
+This is also the testing entry point, since it's the only subcommand
+with no side effects.
+Running it on [[edumail]]'s example emails:
+\begin{pycode}
+output = subprocess.run(["./mutt-nytid", "derive", "email1.txt"],
+                        capture_output=True, env=demoenv)
+print_verbatim(output.stdout)
+\end{pycode}
+(As in the [[edumail]] documentation, we point [[XDG_CONFIG_HOME]] away
+from the author's personal rules file when compiling this document.)
+
+\subsection{Opening an email}
+
+[[open]] is bound to every way of bringing a new message into the
+pager.
+Rather than stopping everything and starting fresh, it computes set
+differences against what we own:
+labels no longer derived are stopped, newly derived ones are started,
+and labels in both sets are simply left running.
+Reading five emails about the same course in a row therefore yields one
+continuous interval per label instead of five fragments---closer to the
+truth about how the time was spent, and less churn in the tracking
+history.
+<<functions>>=
+open() {
+  local file=$(file_or_stdin "$1")
+  local derived=$(derive "$file")
+  stop_labels $(comm -23 <(current_labels) <(echo "${derived}"))
+  start_labels $(comm -13 <(current_labels) <(echo "${derived}"))
+}
+@ The unquoted command substitutions are deliberate:
+the label-per-line output word-splits into one argument per label, and
+an empty difference becomes no arguments at all, which
+[[start_labels]]/[[stop_labels]] treat as \enquote{nothing to do}.
+
+Returning to the index stops everything we own.
+<<functions>>=
+close() {
+  stop_labels $(current_labels)
+}
+@
+
+\subsection{Replying: the editor wrapper}\label{EditorWrapper}
+
+There is no way to run a command when a reply is finished:
+[[mutt]] has no such hook, and a macro cannot help either---any keys
+placed after [[<reply>]] in a macro are consumed by the compose
+prompts, not executed afterwards.
+
+But we don't need one.
+[[mutt]] invokes the editor synchronously, and our [[~/.muttrc]] sets
+[[edit_headers]], so the draft file the editor receives is a complete
+message: [[To:]], [[Subject:]], and the quoted original.
+That is exactly the input [[edumail labels]] was designed for (its
+sender extraction reads [[To:]] precisely because we parse our own
+replies).
+So we point [[mutt]]'s [[$editor]] at this wrapper:
+it derives labels from the draft itself and lets
+[[nytid track start ... --]] run the real editor, which stops those
+labels the moment the editor exits.
+One mechanism covers reply, group-reply, list-reply, forward, fresh
+compose, and---because an aborted reply also exits the editor---aborts
+too.
+<<functions>>=
+editor() {
+  local real_editor="${VISUAL:-${EDITOR:-vi}}"
+  if ! command -v nytid > /dev/null; then
+    exec "${real_editor}" "$@"
+  fi
+  local labels
+  labels=$( (derive "$1"; echo replying) | sort -u \
+            | comm -23 - <(active_labels) )
+  if [[ -z "${labels}" ]]; then
+    exec "${real_editor}" "$@"
+  fi
+  exec nytid track start ${labels} -- "${real_editor}" "$@"
+}
+@ Several details carry the safety here.
+First, if [[nytid]] is missing or broken we must still open the
+editor---losing time tracking is annoying, losing the ability to write
+email is not acceptable.
+
+Second, some derived labels may already be running:
+we usually reply from the pager, where [[open]] started them.
+[[nytid]]'s launch mode \emph{refuses} to start when any requested
+label is already active---it insists on sole ownership of the labels it
+will stop when the command exits.
+The alternatives it offers would both steal the pager's timers
+([[--replace]] restarts them, [[--continue]] adopts them and stops them
+at editor exit), so we do the third thing:
+subtract everything already active and launch only the rest.
+The pager's timers then run untouched through the reply and are stopped
+by [[close]] as usual, while the reply-only labels---normally just
+[[replying]]---stop with the editor.
+We deliberately do \emph{not} record the launched labels in
+[[current]]:
+[[nytid]] stops them itself, and double bookkeeping would have
+[[close]] trying to stop them a second time.
+([[nytid]] also adds the editor's name as a label, so reply time is
+additionally visible under [[vim]]; that comes free with the launch
+mechanism.)
+
+Third, if the subtraction leaves nothing (essentially impossible, since
+[[replying]] is not otherwise used), we must run the editor plainly:
+[[nytid track start]] with \emph{no} labels means \enquote{resume the
+last-stopped labels}, which is never what a reply should do.
+
+Asking what is active means parsing [[nytid track status]], whose
+per-label lines are indented and give the label up to the first colon.
+That parse would misread a label containing a colon, but no label this
+integration creates contains one.
+<<functions>>=
+active_labels() {
+  nytid track status 2>/dev/null \
+  | sed -n 's/^  \([^:]*\):.*/\1/p' | sort -u
+}
+@
+
+\subsection{Adjusting labels while reading}
+
+Automatic derivation will be wrong sometimes.
+The [[edit]] subcommand is bound to a key in the pager and runs in the
+terminal (via [[<shell-escape>]]), where it can talk to us:
+it presents the currently owned labels on a [[readline]] line for
+editing in place.
+The edited set is reconciled exactly like [[open]] does---stop what was
+removed, start what was added---so a label we keep simply continues
+running and loses no time.
+This only affects the current email;
+a recurring correction belongs in the rules file instead.
+<<functions>>=
+edit() {
+  local current=$(current_labels | tr '\n' ' ')
+  echo "Tracked labels for this email: ${current:-none}"
+  local edited
+  read -e -p "Edit labels: " -i "${current}" edited || return 0
+  local wanted=$(printf '%s\n' ${edited} | sort -u)
+  stop_labels $(comm -23 <(current_labels) <(echo "${wanted}"))
+  start_labels $(comm -13 <(current_labels) <(echo "${wanted}"))
+  echo "Now tracking: $(current_labels | tr '\n' ' ')"
+}
+@ Aborting the prompt with control-C or control-D leaves everything as
+it was.
+
+\subsection{Cleaning up}
+
+The wrapper calls [[cleanup]] after the mail client exits, however it
+exited:
+a normal quit, quit-without-sync, or a crash.
+Anything we still own is stopped and the session's state directory is
+removed, so stale sessions can't accumulate.
+<<functions>>=
+cleanup() {
+  close
+  rm -rf "${STATE_DIR}"
+}
+@
+
+
+\section{The mutt configuration}
+
+The [[mutt]] side is a handful of macros.
+All syntax below is understood by both [[mutt]] and [[neomutt]].
+
+First two settings.
+[[wait_key]] would otherwise pause with \enquote{Press any key to
+continue} after every [[<shell-escape>]]/[[<pipe-message>]], turning
+each opened email into two keypresses; our commands are silent on
+success, so nothing useful is lost.
+The [[editor]] is the wrapper from \cref{EditorWrapper}.
+<<[[.muttrc.nytid]]>>=
+set wait_key = no
+set editor = "~/bin/mutt-nytid editor"
+@
+
+Opening from the index:
+pipe the message to [[open]], then display it.
+[[<pipe-message>]] respects [[pipe_decode]] (set in our [[~/.muttrc]]),
+so the script sees a decoded body---better for keyword matching than
+raw quoted-printable---while the headers it needs are kept.
+<<[[.muttrc.nytid]]>>=
+macro index <return> \
+  "<pipe-message>~/bin/mutt-nytid open<enter><display-message>" \
+  "track and read message"
+macro index <enter> \
+  "<pipe-message>~/bin/mutt-nytid open<enter><display-message>" \
+  "track and read message"
+@ Both [[<return>]] and [[<enter>]] are bound, since terminals differ
+in which of the two the return key produces.
+
+Leaving the pager for the index:
+<<[[.muttrc.nytid]]>>=
+macro pager i "<shell-escape>~/bin/mutt-nytid close<enter><exit>" \
+  "untrack and exit pager"
+macro pager q "<shell-escape>~/bin/mutt-nytid close<enter><exit>" \
+  "untrack and exit pager"
+@
+
+Moving between messages without leaving the pager bypasses the index
+bindings, so the navigation keys retarget the tracking themselves.
+No [[close]] is needed: [[open]]'s set-difference reconciliation
+\emph{is} the close for whatever the previous message no longer
+justifies.
+<<[[.muttrc.nytid]]>>=
+macro pager J "<next-entry><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "track and view next message"
+macro pager K \
+  "<previous-entry><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "track and view previous message"
+@ A known leak remains:
+anything else that auto-advances the pager (deleting with [[d]] when
+[[resolve]] is set, for instance) keeps the previous email's labels
+running until the next [[open]] or [[close]].
+We accept that rather than wrapping every such key; wrap [[d]] the same
+way as [[J]] if it turns out to matter.
+
+Finally, adjusting the labels while reading (or from the index):
+<<[[.muttrc.nytid]]>>=
+macro index,pager ,l "<shell-escape>~/bin/mutt-nytid edit<enter>" \
+  "edit tracking labels"
+@ Note there are no reply macros anywhere:
+reply tracking is entirely the editor wrapper's, by design
+(\cref{EditorWrapper}).
+
+
+\section{The mutt wrapper}
+
+The wrapper used to [[exec]] into [[nytid track start mutt -- neomutt]].
+Losing [[exec]] costs one waiting shell process but buys the guarantee
+this design needs:
+something runs \emph{after} the mail client exits and reaps whatever
+per-email labels are still running, no matter how the client ended.
+The exported session id gives the helper script its per-instance state
+directory (\cref{TheHelperScript}).
+<<[[mutt.sh]]>>=
+#!/bin/sh
+NEOMUTT=/usr/bin/neomutt
+MUTT_NYTID_SESSION=$$
+export MUTT_NYTID_SESSION
+nytid track start mutt -- "$NEOMUTT" "$@"
+status=$?
+"$HOME/bin/mutt-nytid" cleanup
+exit $status
+@ The [[mutt]] session label itself still needs no cleanup here:
+[[nytid]]'s launch mechanism stops it when [[neomutt]] exits, exactly
+as before.
+
+
+\section{Seed rules}
+
+The rules file format is documented with [[edumail labels]]; this seed
+only has to get a user started.
+It is installed only when no rules file exists yet, so it never
+overwrites rules the user has written.
+<<[[labels.rules]]>>=
+# Rules mapping email patterns to nytid time-tracking labels,
+# read by `edumail labels` (see edumail.pdf for the format).
+#
+#   [field:]PCRE<whitespace>label...
+#
+# field is from, subject or any (the default: anywhere in the
+# cleaned email).  Patterns are case-insensitive Perl regexes and
+# cannot contain whitespace; use \s instead.
+
+from:.*@ug\.kth\.se     admin
+@
+
+
+\section{The scripts as a whole}
+
+The helper script reads like this:
+\inputminted{bash}{mutt-nytid.sh}
+
+And the [[mutt]] configuration:
+\inputminted{text}{.muttrc.nytid}
+
+\printbibliography{}
+
+\end{document}

--- a/muttnytid.nw
+++ b/muttnytid.nw
@@ -196,7 +196,17 @@ so two mail clients running at the same time keep separate books.
 STATE_DIR="${XDG_RUNTIME_DIR:-$HOME/.cache}/mutt-nytid"
 STATE_DIR="${STATE_DIR}/${MUTT_NYTID_SESSION:-default}"
 CURRENT="${STATE_DIR}/current"
+LAST_BATCH="${STATE_DIR}/last-batch"
 @
+
+A second file, [[last-batch]], records which labels the latest
+[[start_labels]] actually started \emph{together}---in [[nytid]]
+terms one batch, sharing one start time.
+Since [[open]] resets it, it describes the current email:
+the labels whose tracking began the moment this email was opened.
+Nothing in the core open/close cycle needs it; it exists for [[edit]]
+(\cref{AdjustingLabels}), which must point [[nytid]] at
+\enquote{the batch that stands for this email}.
 
 Reading the record must work before the first [[open]] has created it,
 so a missing file just means we own nothing yet.
@@ -218,6 +228,9 @@ derived label happens to already run for some other reason, it never
 enters our record and we will never stop it.
 (This also means labels must not contain spaces or commas, which
 [[nytid]]'s own command line syntax already imposes.)
+The confirmed labels also overwrite [[last-batch]]:
+they started together just now, forming the batch that later
+additions may join.
 <<functions>>=
 start_labels() {
   [[ $# -eq 0 ]] && return 0
@@ -226,6 +239,7 @@ start_labels() {
   started=$(nytid track start "$@" \
             | sed -n 's/^Started tracking: //p' \
             | tr -d ' ' | tr ',' '\n')
+  echo "${started}" | grep -v '^$' > "${LAST_BATCH}"
   (current_labels; echo "${started}") \
     | sort -u | grep -v '^$' > "${CURRENT}.new"
   mv "${CURRENT}.new" "${CURRENT}"
@@ -239,6 +253,9 @@ stop exactly the named labels, then drop them from the record.
 We drop them even if [[nytid]] complains---a label that isn't running
 anymore (say, stopped from another terminal) shouldn't stay in our
 books either.
+A stopped label also leaves [[last-batch]]:
+both state files obey the same invariant, never listing a label we no
+longer track.
 <<functions>>=
 stop_labels() {
   [[ $# -eq 0 ]] && return 0
@@ -247,6 +264,9 @@ stop_labels() {
   comm -23 <(current_labels) <(printf '%s\n' "$@" | sort -u) \
     > "${CURRENT}.new"
   mv "${CURRENT}.new" "${CURRENT}"
+  comm -23 <(sort -u "${LAST_BATCH}" 2>/dev/null) \
+    <(printf '%s\n' "$@" | sort -u) > "${LAST_BATCH}.new"
+  mv "${LAST_BATCH}.new" "${LAST_BATCH}"
 }
 @
 
@@ -294,10 +314,15 @@ history.
 open() {
   local file=$(file_or_stdin "$1")
   local derived=$(derive "$file")
+  mkdir -p "${STATE_DIR}"
+  : > "${LAST_BATCH}"
   stop_labels $(comm -23 <(current_labels) <(echo "${derived}"))
   start_labels $(comm -13 <(current_labels) <(echo "${derived}"))
 }
-@ The unquoted command substitutions are deliberate:
+@ We reset [[last-batch]] before anything else:
+if every derived label carries over and nothing needs starting, the
+empty file correctly records that no batch stands for this email.
+The unquoted command substitutions are deliberate:
 the label-per-line output word-splits into one argument per label, and
 an empty difference becomes no arguments at all, which
 [[start_labels]]/[[stop_labels]] treat as \enquote{nothing to do}.
@@ -385,16 +410,13 @@ active_labels() {
 }
 @
 
-\subsection{Adjusting labels while reading}
+\subsection{Adjusting labels while reading}\label{AdjustingLabels}
 
 Automatic derivation will be wrong sometimes.
 The [[edit]] subcommand is bound to a key in the pager and runs in the
 terminal (via [[<shell-escape>]]), where it can talk to us:
 it presents the currently owned labels on a [[readline]] line for
 editing in place.
-The edited set is reconciled exactly like [[open]] does---stop what was
-removed, start what was added---so a label we keep simply continues
-running and loses no time.
 This only affects the current email;
 a recurring correction belongs in the rules file instead.
 <<functions>>=
@@ -404,12 +426,114 @@ edit() {
   local edited
   read -e -p "Edit labels: " -i "${current}" edited || return 0
   local wanted=$(printf '%s\n' ${edited} | sort -u)
-  stop_labels $(comm -23 <(current_labels) <(echo "${wanted}"))
-  start_labels $(comm -13 <(current_labels) <(echo "${wanted}"))
+  local added=$(comm -13 <(current_labels) <(echo "${wanted}"))
+  local removed=$(comm -23 <(current_labels) <(echo "${wanted}"))
+  if nytid_can_edit_batches; then
+    relabel "${added}" "${removed}"
+  else
+    stop_labels ${removed}
+    start_labels ${added}
+  fi
   echo "Now tracking: $(current_labels | tr '\n' ' ')"
 }
 @ Aborting the prompt with control-C or control-D leaves everything as
 it was.
+
+How the edited set takes effect matters more than it looks.
+The obvious mechanism---stop the removed labels, start the added
+ones---has two flaws when the reason for editing is \emph{wrong
+inference}:
+stopping a wrong label writes a history entry, permanently attributing
+the time to something we just declared wrong; and a label added now
+loses the minutes already spent reading before we noticed.
+The hashless [[nytid track edit]] (nytid issue~472) fixes both:
+[[--containing <label>]] targets the active batch holding a label,
+[[-r]] removes a label \emph{discarding} its accrued time
+([[--discard]] permits this even for a batch's last label), and [[-a]]
+adds labels that join \emph{retroactively} at the batch's start
+time---the moment the email was opened.
+
+Not every [[nytid]] on a machine running this script has that feature
+yet, so we probe for it and keep the stop/start reconciliation as the
+fallback.
+Probing the help text is crude but honest:
+it tests the exact option we intend to pass, rather than a version
+number that says nothing about a patched or backported build.
+<<functions>>=
+nytid_can_edit_batches() {
+  nytid track edit --help 2>/dev/null | grep -q -e --containing
+}
+@
+
+The batch-aware path handles additions before removals on purpose.
+The common correction is a swap---the course was inferred wrong, so
+one label is removed and another added.
+Adding first lets the new label join the wrong label's still-existing
+batch and inherit its start time; only then is the wrong label
+discarded.
+The other way around, discarding a batch's sole wrong label would
+destroy the batch, and the start time with it.
+<<functions>>=
+relabel() {
+  local added="$1"
+  local removed="$2"
+  <<add [[added]] to this email's batch, or start them now>>
+  <<discard each of [[removed]] from its batch>>
+}
+@
+
+Additions are anchored on the [[last-batch]] file:
+any one label from it identifies, via [[--containing]], the batch that
+[[nytid]] should extend.
+When there is no anchor---every derived label carried over from an
+earlier email, so nothing was freshly started---no batch stands for
+this email and there is no start time to inherit;
+we fall back to starting the additions now (and, through
+[[start_labels]], they then form a batch of their own and become the
+anchor for any later additions).
+The same fallback catches [[nytid]] refusing the edit, for instance
+when an added label is already active in someone else's batch.
+Labels added through the batch join it, so they too become valid
+anchors.
+<<add [[added]] to this email's batch, or start them now>>=
+local anchor=$(head -n 1 "${LAST_BATCH}" 2>/dev/null)
+if [[ -n "${added}" ]]; then
+  if [[ -n "${anchor}" ]] \
+     && nytid track edit --containing "${anchor}" \
+          $(printf -- '-a %s\n' ${added}) > /dev/null 2>&1
+  then
+    (current_labels; echo "${added}") | sort -u > "${CURRENT}.new"
+    mv "${CURRENT}.new" "${CURRENT}"
+    (sort -u "${LAST_BATCH}"; echo "${added}") \
+      | sort -u > "${LAST_BATCH}.new"
+    mv "${LAST_BATCH}.new" "${LAST_BATCH}"
+  else
+    start_labels ${added}
+  fi
+fi
+@
+
+Each removal targets the removed label's \emph{own} batch---this is
+exactly what [[--containing]] buys us, since our labels accumulate
+across batches as emails go by.
+If [[nytid]] refuses (say, the label was already stopped from another
+terminal), we fall back to a plain stop, and in either case drop the
+label from both state files, mirroring [[stop_labels]]' policy of
+never keeping a label we no longer track.
+<<discard each of [[removed]] from its batch>>=
+local label
+for label in ${removed}; do
+  nytid track edit --containing "${label}" -r "${label}" --discard \
+    > /dev/null 2>&1 \
+  || nytid track stop "${label}" > /dev/null 2>&1 \
+  || true
+  comm -23 <(current_labels) <(echo "${label}") > "${CURRENT}.new"
+  mv "${CURRENT}.new" "${CURRENT}"
+  comm -23 <(sort -u "${LAST_BATCH}" 2>/dev/null) <(echo "${label}") \
+    > "${LAST_BATCH}.new"
+  mv "${LAST_BATCH}.new" "${LAST_BATCH}"
+done
+@
 
 \subsection{Cleaning up}
 

--- a/nymutt.nw
+++ b/nymutt.nw
@@ -106,8 +106,9 @@ This document tangles four files that cooperate:
   mail client exits.
 \item[\normalfont [[<<[[labels.rules]]>>]] ]
   installed as [[~/.config/edumail/labels.rules]] (only if absent):
-  seed rules for [[edumail labels]], see the edumail documentation for
-  the format.
+  seed rules for [[edumail labels]], translated from the author's
+  [[mutt]] scoring rules (\cref{SeedRules}); see the edumail
+  documentation for the format.
 \end{description}
 
 A reading session then works like this.
@@ -717,12 +718,59 @@ exit $status
 as before.
 
 
-\section{Seed rules}
+\section{Seed rules}\label{SeedRules}
 
 The rules file format is documented with [[edumail labels]]; this seed
 only has to get a user started.
 It is installed only when no rules file exists yet, so it never
 overwrites rules the user has written.
+
+Rather than invent a starting set, we translate one that already exists:
+the author's [[mutt]] scoring rules ([[~/.muttrc.scores]]).
+Scoring answers \enquote{how important is this email?} and a label rule
+answers \enquote{what is this email about?}, but both are decided on the
+same evidence---who sent it and what the subject says---and the scoring
+file is where years of that judgement have accumulated.
+What a score line lacks is a \emph{name} for the thing it recognises, so
+the translation is done by hand, once, rather than by a script.
+The mechanical part is small:
+[[~s]] becomes [[subject:]], [[mutt]]'s [[\|]] alternation becomes PCRE
+[[|]], and spaces inside patterns become [[\s]] because the rules format
+splits on whitespace.
+[[~f]] is the interesting one.
+The rules format has a [[from:]] prefix, but we mostly do \emph{not} use
+it, because the rules must also work when we \emph{write}:
+the editor wrapper (\cref{EditorWrapper}) derives labels from the draft,
+and there the [[From:]] line is us and the person we care about is in
+[[To:]] or [[Cc:]].
+An unprefixed pattern matches anywhere in the cleaned email, and
+[[edumail]]'s [[clean]] keeps the recipient lines, so one such rule
+covers reading and writing alike.
+The semantics shift from [[mutt]]'s \enquote{sent by} to \enquote{a
+party to}, which is what time tracking wants anyway:
+writing to a teaching assistant is TA work too.
+The same holds for [[mutt]]'s own recipient patterns ([[~t]], [[~c]]).
+
+One difference is easy to miss.
+[[mutt]] matches case-insensitively \emph{unless} the pattern contains an
+upper-case letter, so [[~s TA]] finds teaching assistants but not the
+Swedish verb \enquote{ta}, which opens half of all Swedish subject lines.
+[[edumail]] always greps with [[-i]], so a naive translation would put
+[[TA-management]] on most of the inbox.
+PCRE lets a group opt out of the outer flag, [[(?-i:...)]], and every
+all-caps token below (TA, CSN, LAB1, the programme codes, the learned
+societies) is wrapped that way.
+
+Not everything in the scoring file names a topic.
+Rules on age, flags and urgency words rank emails without saying what
+they are about, and domain-wide rules (anything from a Swedish
+university) would put a label on nearly every email; both kinds are left
+out.
+So are the courses that [[edumail labels]] already recognises by keyword
+(programming, datintro, crypto, science):
+the seed only adds the courses it does not.
+
+The file opens with the format reminder from the original one-line seed.
 <<[[labels.rules]]>>=
 # Rules mapping email patterns to nytid time-tracking labels,
 # read by `edumail labels` (see edumail.pdf for the format).
@@ -732,8 +780,198 @@ overwrites rules the user has written.
 # field is from, subject or any (the default: anywhere in the
 # cleaned email).  Patterns are case-insensitive Perl regexes and
 # cannot contain whitespace; use \s instead.
+@
 
-from:.*@ug\.kth\.se     admin
+\subsection{People}
+
+Senders are the bulk of the scoring file and pose the first design
+choice: one label per person, or one per role?
+A per-person label is precise but grows the label set with every new
+contact, and the sum we want at the end of a period is \enquote{time on
+TA matters}, not \enquote{time on email from X}.
+So people map to a handful of roles---[[admin]], [[colleague]],
+[[TA-management]], [[research]]---and someone of interest in two
+respects gets two labels, such as [[colleague CSE]] for a colleague who is
+also in computing-education research.
+
+The patterns match names, not addresses.
+A name is what the header lines show, and it survives the address
+changes (department subdomains, private addresses) that the scoring file
+had to enumerate.
+Functional senders---scheduling, support desks, programme
+administrators---have no name and keep their addresses.
+None of these rules carries a [[from:]] prefix, so they fire for a
+person in [[To:]] or [[Cc:]] as well as in [[From:]]---and, in the
+bargain, for a full name mentioned in the body.
+We accept the latter:
+an email that talks about a colleague by full name is usually about that
+colleague's matter, and the names are long enough not to occur by
+accident.
+Where the scoring file had only a username, the name came from
+[[kthutils ug user <username>]], which is also how to extend the list.
+<<[[labels.rules]]>>=
+# administration and support
+.*@ug\.kth\.se                                      admin
+schema@admin\.kth\.se                               schedule admin
+@timeedit\.com                                      schedule admin
+education-support@eecs\.kth\.se                     admin examination
+service@eecs\.kth\.se                               admin
+(student-support|hr-support)@eecs\.kth\.se          admin
+pa-.*@.*\.kth\.se                                   admin
+Anna\sOlanås\sJansson                               admin hr
+Hanna\sHolmqvist                                    admin hr
+it-support@kth\.se                                  it
+subject:ID:KTH-INC                                  admin
+e-learning@kth\.se                                  canvas admin
+teachers@(.*\.)?kth\.se                             mailinglist
+@indek\.kth\.se                                     indek
+subject:(kompletterande\s|I-)perspektiv|indek|I-student  indek
+@
+
+Each colleague gets a line of their own rather than a place in one long
+alternation, so that a single line can be deleted or relabelled when
+someone changes role.
+<<[[labels.rules]]>>=
+# colleagues
+Viggo\sKann                                         colleague
+Karl\sMeinke                                        colleague
+Anna-Karin\sHögfeldt                                colleague
+Sonja\sBuchegger                                    colleague
+Gerald.*Maguire                                     colleague
+Richard.*Glassey                                    colleague
+Ol(le|of)\sB[äa]lter                                colleague
+Linda\sKann                                         colleague
+Martin\sMonperrus                                   colleague
+Emma\sRiese                                         colleague
+Camilla\sBjörn                                      colleague
+Leif\sKari                                          colleague
+Mats\sNäslund                                       colleague
+Alexander\sBaltazis                                 colleague
+Olga\sViberg                                        colleague CSE
+OB1|Bälter                                          colleague CSE
+Glassey                                             colleague CSE
+Antonio\sMaffei                                     colleague
+Jan-Erik\sJonsson                                   colleague
+Lennart\sFranked                                    colleague
+Martin\sKjellqvist                                  colleague
+# research contacts
+Mathieu\sGestin                                     research security
+Davide\sFrey                                        research security
+Guillaume\sPiolle                                   research security
+Laurie\sGale                                        research CSE
+Francisco\sGomes                                    research CSE
+Bedour\sAlshaigy                                    research CSE
+Johan\sSnider                                       colleague CSE
+Simone\sFischer-H(ü|ue)bner                         swits research security
+subject:swits                                       swits research security
+@
+
+\subsection{Courses}
+
+[[edumail labels]] emits every course code that appears literally in an
+email, so a rule keyed on a code alone would be redundant.
+The course rules below exist for the nicknames and module names students
+use instead of codes ([[inda]], [[tilda]], [[exjobb]]), and they emit
+the same year-free nicknames as [[edumail]]'s built-in tests, so time on
+a course accumulates under one label however the student refers to it.
+Students rarely write a telling subject line, so these rules are not
+restricted to the subject; they match the body too, like [[edumail]]'s
+built-in course tests.
+The price of searching the body is that short stems need word
+boundaries: [[inda]] is inside \enquote{individuell}, and [[tilda]] is
+anchored the same way for consistency.
+Thesis work gets a [[supervision]] label on top of the course, because
+supervision is what we sum up separately from teaching.
+Assignment groups ([[LAB1]], [[INL1]]) need no rules either:
+[[edumail labels]] emits them itself.
+The one module rule left maps the Excel and mathematics modules of the
+programming course to the course, since a student writing about
+[[KAL1]] alone has not named it.
+<<[[labels.rules]]>>=
+# courses beyond the ones edumail recognises by keyword
+DD1337|\binda\b                                     inda
+DD1320|\btilda[vh]?\b                               tilda
+DD139[01]|prosam                                    prosam
+DA150X|dkex|dkand|kex-?jobb|kandidat                dkand supervision
+bachelor.*thesis                                    dkand supervision
+DA231X|exjobb|master.*thesis                        exjobb supervision
+(?-i:\b(KAL1|MAT1)\b)                               prgi
+(?-i:\b(CINEK|CMAST|CITEH|CDATE)\b)                 programme
+(?-i:\b(CFATE|CTMAT|CTFYS|CLGYM)\b)                 programme
+@
+
+\subsection{Topics}
+
+The topic rules reuse the labels we already track by hand---[[grading]],
+[[ladok]], [[restlabb]], [[TA-management]], [[reporting]],
+[[meeting]]---so that email time lands in the same buckets as the rest
+of the work on that topic.
+Several rules carry two labels for the same reason:
+a timesheet from a TA is both [[reporting]] and [[TA-management]], and
+the concurrent-label model costs nothing for saying so.
+The grading-related rules (Ladok, grades, resubmissions, examination,
+credit transfer, CSN) are unprefixed for the same reason as the course
+rules: they come from students, who put the matter in the body.
+Here too the body forces a tighter pattern:
+[[rester]] alone would match the everyday \enquote{resterande}, so
+resubmissions are [[rest(er\b|labb|uppgift|inlämn)]].
+The remaining topics keep the [[subject:]] prefix; words like
+\enquote{timmar}, \enquote{sjuk} or \enquote{fråga} are far too common
+in running text to be labels on their own.
+<<[[labels.rules]]>>=
+# topics
+subject:ti[dm]s?(rapport|ersättning)|time\s?sheet   reporting TA-management
+subject:lön|timmar|arvode                           reporting TA-management
+subject:\b(assning|asse|assistent)\b|(?-i:\bTA\b)   TA-management
+ladok|betyg                                         ladok grading examination
+kompletter(a|ing)|rätt(ad?|ning)                    grading examination
+redovis(a|ning)                                     grading examination
+examin(era|ation)                                   examination
+\brest(er\b|labb|uppgift|inlämn)                    restlabb examination
+(?-i:\bCSN\b)                                       csn examination
+tillgodoräk                                         tillgodo admin
+subject:kurs-?(analys|pm|(ut)?värdering)            course-admin
+subject:TEL.(meeting|möte)                          tel meeting
+subject:cerise                                      cerise
+subject:cron.*dbosk@rpi                             admin scripts
+from:Calendly                                       meeting
+subject:receipt\sfrom\sAnthropic                    expenses admin
+subject:(reviewer.*invitation|invitation.*reviewer) reviewing research
+from:KTH\sSurvey                                    survey
+@
+
+Notification streams from tools are labelled by the tool, since the
+tool usually implies the activity: Canvas and FeedbackFruits mean
+teaching, GitHub means development, Urkund means grading.
+<<[[labels.rules]]>>=
+# tools and notification streams
+from:Canvas|notifications@instructure\.com          canvas
+from:feedbackfruits                                 feedbackfruits canvas
+from:GitHub|notifications@github\.com               devel
+from:Zulip                                          zulip
+from:noreply@urkund\.se                             urkund grading
+subject:SIGCSE-members                              mailinglist CSE
+@
+
+\subsection{Newsletters}
+
+The scoring file ends with what it pushes \emph{down}: newsletters,
+alerts and society mailings.
+Skimming them still costs time, so they get a label rather than none,
+and the digests that feed literature awareness get [[research]] too, so
+that this time is counted where it belongs.
+The society acronyms are matched case-sensitively; [[acm]] and
+[[sans]] are substrings of too many names.
+<<[[labels.rules]]>>=
+# newsletters and digests
+from:Google\sScholar|Springer\sAlert|ScienceDirect  newsletter research
+from:Nature\sBriefing|News\sfrom\sScience           newsletter research
+subject:Aktuell\shögskolepedagogisk\sforskning      newsletter research
+from:ACM\sDigital\sLibrary|Xplore                   newsletter research
+from:(?-i:\b(IEEE|ACM|SIAM)\b)                      newsletter research
+from:The\sDownload|Times\sHigher\sEducation         newsletter
+from:(?-i:\bSANS\b)|EIT\sDigital                    newsletter
+from:KTH\s(Magazine|Opportunities\sFund|Alumni)     newsletter
 @
 
 

--- a/nymutt.nw
+++ b/nymutt.nw
@@ -10,7 +10,7 @@
 \setjobnamebeamerversion{slides}
 
 \title{%
-  Tracking email time in mutt with nytid
+  nymutt: tracking email time in mutt with nytid
 }
 \author{%
   Daniel Bosk
@@ -91,14 +91,14 @@ For replies we use a different trick, described in
 
 This document tangles four files that cooperate:
 \begin{description}
-\item[\normalfont [[<<[[mutt-nytid.sh]]>>]] ]
-  installed as [[~/bin/mutt-nytid]]:
+\item[\normalfont [[<<[[nymutt.sh]]>>]] ]
+  installed as [[~/bin/nymutt]]:
   the helper script that [[mutt]] calls.
   It derives labels (via [[edumail labels]]), starts and stops
   [[nytid]] timers, and keeps state about which labels \emph{it}
   started.
-\item[\normalfont [[<<[[.muttrc.nytid]]>>]] ]
-  installed as [[~/.muttrc.nytid]] and sourced from [[~/.muttrc]]:
+\item[\normalfont [[<<[[.muttrc.nymutt]]>>]] ]
+  installed as [[~/.muttrc.nymutt]] and sourced from [[~/.muttrc]]:
   the macros and settings that wire the helper into [[mutt]].
 \item[\normalfont [[<<[[mutt.sh]]>>]] ]
   installed as [[~/bin/mutt]]:
@@ -112,17 +112,17 @@ This document tangles four files that cooperate:
 
 A reading session then works like this.
 Pressing return in the index pipes the message to
-[[mutt-nytid open]], which starts the derived labels, and then displays
+[[nymutt open]], which starts the derived labels, and then displays
 the message.
-Leaving the pager runs [[mutt-nytid close]], which stops them.
+Leaving the pager runs [[nymutt close]], which stops them.
 Moving to the next message from within the pager runs [[open]] again,
 which retargets the timers:
 labels shared with the previous email simply keep running.
 Replying opens the editor, which [[mutt]] is configured to reach
-through [[mutt-nytid editor]]---the wrapper tracks the [[replying]]
+through [[nymutt editor]]---the wrapper tracks the [[replying]]
 label for exactly as long as the editor runs.
 And when the mail client exits, the [[mutt]] wrapper calls
-[[mutt-nytid cleanup]] so no per-email timer can outlive the session.
+[[nymutt cleanup]] so no per-email timer can outlive the session.
 
 
 \section{The helper script}\label{TheHelperScript}
@@ -131,7 +131,7 @@ The script follows the same conventions as [[edumail]]:
 subcommands are functions, dispatched by a [[main]] that is skipped
 when the script is sourced, and functions that read a message accept a
 filename or fall back to stdin.
-<<[[mutt-nytid.sh]]>>=
+<<[[nymutt.sh]]>>=
 #!/bin/bash
 
 <<variables>>
@@ -190,11 +190,11 @@ Sorted, because the functions below compare label sets with [[comm]],
 which requires sorted input; keeping the file sorted at every write
 means we never have to remember to sort at the reads.
 The file lives in a per-session directory:
-the [[mutt]] wrapper exports [[MUTT_NYTID_SESSION]] (its process id),
+the [[mutt]] wrapper exports [[NYMUTT_SESSION]] (its process id),
 so two mail clients running at the same time keep separate books.
 <<variables>>=
-STATE_DIR="${XDG_RUNTIME_DIR:-$HOME/.cache}/mutt-nytid"
-STATE_DIR="${STATE_DIR}/${MUTT_NYTID_SESSION:-default}"
+STATE_DIR="${XDG_RUNTIME_DIR:-$HOME/.cache}/nymutt"
+STATE_DIR="${STATE_DIR}/${NYMUTT_SESSION:-default}"
 CURRENT="${STATE_DIR}/current"
 LAST_BATCH="${STATE_DIR}/last-batch"
 @
@@ -291,7 +291,7 @@ This is also the testing entry point, since it's the only subcommand
 with no side effects.
 Running it on [[edumail]]'s example emails:
 \begin{pycode}
-output = subprocess.run(["./mutt-nytid", "derive", "email1.txt"],
+output = subprocess.run(["./nymutt", "derive", "email1.txt"],
                         capture_output=True, env=demoenv)
 print_verbatim(output.stdout)
 \end{pycode}
@@ -566,10 +566,10 @@ silently advances to the next message, bypassing every macro below.
 With it, space stops at the end and moving on is always an explicit
 key we \emph{have} wrapped.
 The [[editor]] is the wrapper from \cref{EditorWrapper}.
-<<[[.muttrc.nytid]]>>=
+<<[[.muttrc.nymutt]]>>=
 set wait_key = no
 set pager_stop = yes
-set editor = "~/bin/mutt-nytid editor"
+set editor = "~/bin/nymutt editor"
 @
 
 Opening from the index:
@@ -584,30 +584,30 @@ message, just with full headers.
 Keys that merely move the index selection---tab
 ([[<next-new-then-unread>]]), [[j]]/[[k]], arrows---need no wrapping:
 no message is displayed, so no tracking should start.
-<<[[.muttrc.nytid]]>>=
+<<[[.muttrc.nymutt]]>>=
 macro index <return> \
-  "<pipe-message>~/bin/mutt-nytid open<enter><display-message>" \
+  "<pipe-message>~/bin/nymutt open<enter><display-message>" \
   "track and read message"
 macro index <enter> \
-  "<pipe-message>~/bin/mutt-nytid open<enter><display-message>" \
+  "<pipe-message>~/bin/nymutt open<enter><display-message>" \
   "track and read message"
 macro index <keypadenter> \
-  "<pipe-message>~/bin/mutt-nytid open<enter><display-message>" \
+  "<pipe-message>~/bin/nymutt open<enter><display-message>" \
   "track and read message"
 macro index <space> \
-  "<pipe-message>~/bin/mutt-nytid open<enter><display-message>" \
+  "<pipe-message>~/bin/nymutt open<enter><display-message>" \
   "track and read message"
 macro index h \
-  "<pipe-message>~/bin/mutt-nytid open<enter><display-toggle-weed>" \
+  "<pipe-message>~/bin/nymutt open<enter><display-toggle-weed>" \
   "track and read message with full headers"
 @ ([[<keypadenter>]] is a NeoMutt key name; delete that line if this
 file ever feeds a stock mutt.)
 
 Leaving the pager for the index:
-<<[[.muttrc.nytid]]>>=
-macro pager i "<shell-escape>~/bin/mutt-nytid close<enter><exit>" \
+<<[[.muttrc.nymutt]]>>=
+macro pager i "<shell-escape>~/bin/nymutt close<enter><exit>" \
   "untrack and exit pager"
-macro pager q "<shell-escape>~/bin/mutt-nytid close<enter><exit>" \
+macro pager q "<shell-escape>~/bin/nymutt close<enter><exit>" \
   "untrack and exit pager"
 @
 
@@ -629,44 +629,44 @@ mail),
 ([[<next-undeleted>]]/[[<previous-undeleted>]]),
 and the thread motions on control-N/P and escape-n/p.
 We wrap them all with the same tail.
-<<[[.muttrc.nytid]]>>=
-macro pager J "<next-entry><pipe-message>~/bin/mutt-nytid open<enter>" \
+<<[[.muttrc.nymutt]]>>=
+macro pager J "<next-entry><pipe-message>~/bin/nymutt open<enter>" \
   "track and view next message"
 macro pager K \
-  "<previous-entry><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "<previous-entry><pipe-message>~/bin/nymutt open<enter>" \
   "track and view previous message"
 macro pager <tab> \
-  "<next-new-then-unread><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "<next-new-then-unread><pipe-message>~/bin/nymutt open<enter>" \
   "track and view next new message"
 macro pager j \
-  "<next-undeleted><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "<next-undeleted><pipe-message>~/bin/nymutt open<enter>" \
   "track and view next undeleted message"
 macro pager <down> \
-  "<next-undeleted><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "<next-undeleted><pipe-message>~/bin/nymutt open<enter>" \
   "track and view next undeleted message"
 macro pager <right> \
-  "<next-undeleted><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "<next-undeleted><pipe-message>~/bin/nymutt open<enter>" \
   "track and view next undeleted message"
 macro pager k \
-  "<previous-undeleted><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "<previous-undeleted><pipe-message>~/bin/nymutt open<enter>" \
   "track and view previous undeleted message"
 macro pager <up> \
-  "<previous-undeleted><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "<previous-undeleted><pipe-message>~/bin/nymutt open<enter>" \
   "track and view previous undeleted message"
 macro pager <left> \
-  "<previous-undeleted><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "<previous-undeleted><pipe-message>~/bin/nymutt open<enter>" \
   "track and view previous undeleted message"
 macro pager \Cn \
-  "<next-thread><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "<next-thread><pipe-message>~/bin/nymutt open<enter>" \
   "track and view next thread"
 macro pager \Cp \
-  "<previous-thread><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "<previous-thread><pipe-message>~/bin/nymutt open<enter>" \
   "track and view previous thread"
 macro pager \en \
-  "<next-subthread><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "<next-subthread><pipe-message>~/bin/nymutt open<enter>" \
   "track and view next subthread"
 macro pager \ep \
-  "<previous-subthread><pipe-message>~/bin/mutt-nytid open<enter>" \
+  "<previous-subthread><pipe-message>~/bin/nymutt open<enter>" \
   "track and view previous subthread"
 @ One known leak remains:
 deleting with [[d]] auto-advances the pager (via [[resolve]]) without
@@ -681,8 +681,8 @@ label that the next tab press corrects anyway.
 message with full headers, and the labels are already running.)
 
 Finally, adjusting the labels while reading (or from the index):
-<<[[.muttrc.nytid]]>>=
-macro index,pager ,l "<shell-escape>~/bin/mutt-nytid edit<enter>" \
+<<[[.muttrc.nymutt]]>>=
+macro index,pager ,l "<shell-escape>~/bin/nymutt edit<enter>" \
   "edit tracking labels"
 @ Note there are no reply macros anywhere:
 reply tracking is entirely the editor wrapper's, by design
@@ -701,11 +701,11 @@ directory (\cref{TheHelperScript}).
 <<[[mutt.sh]]>>=
 #!/bin/sh
 NEOMUTT=/usr/bin/neomutt
-MUTT_NYTID_SESSION=$$
-export MUTT_NYTID_SESSION
+NYMUTT_SESSION=$$
+export NYMUTT_SESSION
 nytid track start mutt -- "$NEOMUTT" "$@"
 status=$?
-"$HOME/bin/mutt-nytid" cleanup
+"$HOME/bin/nymutt" cleanup
 exit $status
 @ The [[mutt]] session label itself still needs no cleanup here:
 [[nytid]]'s launch mechanism stops it when [[neomutt]] exits, exactly
@@ -735,10 +735,10 @@ from:.*@ug\.kth\.se     admin
 \section{The scripts as a whole}
 
 The helper script reads like this:
-\inputminted{bash}{mutt-nytid.sh}
+\inputminted{bash}{nymutt.sh}
 
 And the [[mutt]] configuration:
-\inputminted{text}{.muttrc.nytid}
+\inputminted{text}{.muttrc.nymutt}
 
 \printbibliography{}
 

--- a/nymutt.nw
+++ b/nymutt.nw
@@ -28,8 +28,8 @@
   We want that tracking to be automatic while reading email:
   when we open an email in [[mutt]], labels derived from the email
   (course, sender, keywords) should start; when we return to the index,
-  they should stop; while we write a reply, a [[replying]] label should
-  run.
+  they should stop; while we write email---a reply or a fresh
+  message---a [[writing]] label should run.
   [[mutt]] has no hooks for leaving the pager or finishing a reply, so we
   build the integration from macro-wrapped key bindings, an editor
   wrapper, and a small state-keeping helper script.
@@ -118,9 +118,10 @@ Leaving the pager runs [[nymutt close]], which stops them.
 Moving to the next message from within the pager runs [[open]] again,
 which retargets the timers:
 labels shared with the previous email simply keep running.
-Replying opens the editor, which [[mutt]] is configured to reach
-through [[nymutt editor]]---the wrapper tracks the [[replying]]
-label for exactly as long as the editor runs.
+Replying---or composing a fresh message---opens the editor, which
+[[mutt]] is configured to reach through [[nymutt editor]]---the
+wrapper tracks the [[writing]] label for exactly as long as the
+editor runs.
 And when the mail client exits, the [[mutt]] wrapper calls
 [[nymutt cleanup]] so no per-email timer can outlive the session.
 
@@ -334,7 +335,7 @@ close() {
 }
 @
 
-\subsection{Replying: the editor wrapper}\label{EditorWrapper}
+\subsection{Writing: the editor wrapper}\label{EditorWrapper}
 
 There is no way to run a command when a reply is finished:
 [[mutt]] has no such hook, and a macro cannot help either---any keys
@@ -355,6 +356,10 @@ labels the moment the editor exits.
 One mechanism covers reply, group-reply, list-reply, forward, fresh
 compose, and---because an aborted reply also exits the editor---aborts
 too.
+That breadth also names the label:
+a fresh message runs this same wrapper, so calling the label
+[[replying]] would mislabel it; [[writing]] is what all these cases
+have in common.
 <<functions>>=
 editor() {
   local real_editor="${VISUAL:-${EDITOR:-vi}}"
@@ -362,7 +367,7 @@ editor() {
     exec "${real_editor}" "$@"
   fi
   local labels
-  labels=$( (derive "$1"; echo replying) | sort -u \
+  labels=$( (derive "$1"; echo writing) | sort -u \
             | comm -23 - <(active_labels) )
   if [[ -z "${labels}" ]]; then
     exec "${real_editor}" "$@"
@@ -384,8 +389,8 @@ The alternatives it offers would both steal the pager's timers
 at editor exit), so we do the third thing:
 subtract everything already active and launch only the rest.
 The pager's timers then run untouched through the reply and are stopped
-by [[close]] as usual, while the reply-only labels---normally just
-[[replying]]---stop with the editor.
+by [[close]] as usual, while the editor-only labels---normally just
+[[writing]]---stop with the editor.
 We deliberately do \emph{not} record the launched labels in
 [[current]]:
 [[nytid]] stops them itself, and double bookkeeping would have
@@ -395,7 +400,7 @@ additionally visible under [[vim]]; that comes free with the launch
 mechanism.)
 
 Third, if the subtraction leaves nothing (essentially impossible, since
-[[replying]] is not otherwise used), we must run the editor plainly:
+[[writing]] is not otherwise used), we must run the editor plainly:
 [[nytid track start]] with \emph{no} labels means \enquote{resume the
 last-stopped labels}, which is never what a reply should do.
 

--- a/nymutt.nw
+++ b/nymutt.nw
@@ -97,8 +97,8 @@ This document tangles four files that cooperate:
   It derives labels (via [[edumail labels]]), starts and stops
   [[nytid]] timers, and keeps state about which labels \emph{it}
   started.
-\item[\normalfont [[<<[[.muttrc.nymutt]]>>]] ]
-  installed as [[~/.muttrc.nymutt]] and sourced from [[~/.muttrc]]:
+\item[\normalfont [[<<[[.muttrc.nytid]]>>]] ]
+  installed as [[~/.muttrc.nytid]] and sourced from [[~/.muttrc]]:
   the macros and settings that wire the helper into [[mutt]].
 \item[\normalfont [[<<[[mutt.sh]]>>]] ]
   installed as [[~/bin/mutt]]:
@@ -566,7 +566,7 @@ silently advances to the next message, bypassing every macro below.
 With it, space stops at the end and moving on is always an explicit
 key we \emph{have} wrapped.
 The [[editor]] is the wrapper from \cref{EditorWrapper}.
-<<[[.muttrc.nymutt]]>>=
+<<[[.muttrc.nytid]]>>=
 set wait_key = no
 set pager_stop = yes
 set editor = "~/bin/nymutt editor"
@@ -584,7 +584,7 @@ message, just with full headers.
 Keys that merely move the index selection---tab
 ([[<next-new-then-unread>]]), [[j]]/[[k]], arrows---need no wrapping:
 no message is displayed, so no tracking should start.
-<<[[.muttrc.nymutt]]>>=
+<<[[.muttrc.nytid]]>>=
 macro index <return> \
   "<pipe-message>~/bin/nymutt open<enter><display-message>" \
   "track and read message"
@@ -604,7 +604,7 @@ macro index h \
 file ever feeds a stock mutt.)
 
 Leaving the pager for the index:
-<<[[.muttrc.nymutt]]>>=
+<<[[.muttrc.nytid]]>>=
 macro pager i "<shell-escape>~/bin/nymutt close<enter><exit>" \
   "untrack and exit pager"
 macro pager q "<shell-escape>~/bin/nymutt close<enter><exit>" \
@@ -629,7 +629,7 @@ mail),
 ([[<next-undeleted>]]/[[<previous-undeleted>]]),
 and the thread motions on control-N/P and escape-n/p.
 We wrap them all with the same tail.
-<<[[.muttrc.nymutt]]>>=
+<<[[.muttrc.nytid]]>>=
 macro pager J "<next-entry><pipe-message>~/bin/nymutt open<enter>" \
   "track and view next message"
 macro pager K \
@@ -681,7 +681,7 @@ label that the next tab press corrects anyway.
 message with full headers, and the labels are already running.)
 
 Finally, adjusting the labels while reading (or from the index):
-<<[[.muttrc.nymutt]]>>=
+<<[[.muttrc.nytid]]>>=
 macro index,pager ,l "<shell-escape>~/bin/nymutt edit<enter>" \
   "edit tracking labels"
 @ Note there are no reply macros anywhere:
@@ -738,7 +738,7 @@ The helper script reads like this:
 \inputminted{bash}{nymutt.sh}
 
 And the [[mutt]] configuration:
-\inputminted{text}{.muttrc.nymutt}
+\inputminted{text}{.muttrc.nytid}
 
 \printbibliography{}
 


### PR DESCRIPTION
Adds automatic nytid time tracking while reading and replying to email
in (neo)mutt, everything tangled from literate sources in this repo.
(The tool was renamed from mutt-nytid to nymutt mid-branch: the mutt-
prefix broke tab completion of `mutt` itself.)

## edumail

- New `labels` subcommand: maps an email to clean time-tracking labels
  (course nicks from the existing keyword-test chunks, literal course
  codes, and user rules from `~/.config/edumail/labels.rules` with
  `from:`/`subject:`/`any` PCRE patterns).
- The kthutils forms data is now fetched lazily and memoized, so
  `labels` runs in ~65 ms on every opened email.

## nymutt (new literate program `nymutt.nw`)

Tangles four files: the `nymutt` helper (nytid state machine),
`.muttrc.nytid` (macros), the `mutt` wrapper (adds post-exit
cleanup), and a seed `labels.rules`.

- Opening an email starts `email` + derived labels; returning to the
  index stops them; every pager key that switches messages retargets
  by set difference, so consecutive same-course emails keep one
  continuous interval. All index/pager entry keys are covered;
  `pager_stop` closes the space-at-end-of-message hole.
- Replying is tracked by an `$editor` wrapper (derives labels from the
  draft, `nytid track start ... -- vim` stops them on editor exit) —
  no reply macros, so nothing collides with compose prompts.
- `,l` edits labels interactively. When nytid has hashless
  `track edit --containing/--discard` (dbosk/nytid#472, verified
  end-to-end against that branch), corrections are applied in place:
  wrong labels discard their time, added labels join retroactively at
  the email's open time. Probed at runtime with a stop/start fallback
  for older nytid.
- Ownership invariant throughout: the helper only ever stops labels it
  started itself, so the session-level `mutt` label and timers started
  elsewhere are never touched.

Related: #3 (DKIM headers matching the course-code regex on raw files;
not addressed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WgSaHqDdoy4YxHYk6huTn


