### PR TITLE
Prefer named courses and recognize TA mail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ edumail.tex: edumail.nw noweb_lexer.py
 
 nymutt.pdf: nymutt.tex didactic.sty
 nymutt.pdf: preamble.tex
-nymutt.pdf: nymutt edumail .muttrc.nytid
+nymutt.pdf: nymutt edumail .muttrc.nytid labels.rules
 
 nymutt.tex: nymutt.nw noweb_lexer.py
 

--- a/edumail.nw
+++ b/edumail.nw
@@ -455,6 +455,29 @@ output = subprocess.run(["./edumail", "course", "email2.txt"],
 print_verbatim(output.stdout)
 \end{pycode}
 
+These two emails show the two ways we can learn the course:
+\cref{email1} names it by code, \cref{email2} only describes it.
+Two more emails show why we must keep the two apart.
+\begin{example}\label{email4}
+A student asking about a missing grade names the course in the body rather 
+than in the subject; the subject names the module.
+\inputminted[highlightlines={3,4,13,14}]{text}{email4.txt}
+The student has told us which course they mean, so we want exactly that 
+course, DD1317, and not every course that the words in the email would 
+suggest.
+\end{example}
+(The header lines of \cref{email4} are what our [[mutt]] writes today.
+The [[Date:]] header and the \enquote{On \ldots\ wrote:} line are among 
+the lines that [[clean]] removes, so they don't disturb the matching.)
+\begin{example}\label{email5}
+A student applying to become a teaching assistant names five course codes: 
+the one they apply for and four they have experience from.
+\inputminted[highlightlines={3,4,14,17,19-20}]{text}{email5.txt}
+Only DD1301 is a course we teach.
+The other codes can't be what we want to look up results for---they are 
+not our courses---so we want DD1301 alone.
+\end{example}
+
 Since any matches may occur several times in the email, we'll sort them and 
 remove duplicates.
 And to deal with output containing several lines, we'll make a disjunct regex 
@@ -509,24 +532,103 @@ declare -A COURSE_CODES=(
 )
 @
 
-The [[course_code]] function will look for the course code in the email.
-If it finds something that looks like a course code, it will return it 
-(printing it to stdout).
-Then it adds the codes of every course whose keywords occur in the email; 
-the unquoted [[$(course_families ...)]] splits the families into their 
-members.
+We'll also need the table read backwards: the nick of a course code.
+A code the table doesn't know is a name in its own right and passes 
+through unchanged---a student naming DD1320 has named a course, just not 
+one of ours.
+We upper-case the code first, since students tend to write codes in lower 
+case.
+<<functions>>=
+nick_of_course_code() {
+  local code="${1^^}" nick
+  for nick in "${!COURSE_CODES[@]}"; do
+    if [[ "${COURSE_CODES[$nick]}" == "${code}" ]]; then
+      echo "${nick}"
+      return
+    fi
+  done
+  echo "${code}"
+}
+@
+
+\subsubsection{Named courses beat guessed ones}
+
+\Cref{email4,email5} tell us that a course the student \emph{names} 
+outranks anything we \emph{guess}.
+The keyword tests are a fallback for the common case that the student names 
+nothing (\cref{email2}); once a code or a nick name is in the email, adding 
+the keyword families only adds noise: \cref{email4} would get [[prgm]] on top 
+of the [[prgi]] the student wrote.
+So we first collect the named courses.
+Codes are translated to nick names, so that a course named both ways 
+counts once; a nick name loses its year, since the year says which 
+\emph{round} was named, not which course.
+<<functions>>=
+named_courses() {
+  local file=$(file_or_stdin "$1")
+  local named=$( (<<courses named in [[file]]>>) | sort -u )
+  <<keep only the known courses among [[named]], if there are any>>
+}
+<<courses named in [[file]]>>=
+clean "$file" | grep -Po "${COURSE_CODE}" \
+| while read -r code; do nick_of_course_code "${code}"; done
+clean "$file" | grep -Po "${COURSE_NICK}" | sed -E 's/[0-9]{2}$//'
+@
+
+\Cref{email5} adds a second rule: among the named courses, the ones we 
+teach outrank the ones we don't.
+A student who names one of our courses together with others has told us 
+which one concerns us; the others are context (previous experience, in 
+\cref{email5}).
+Only when none of the named courses is ours do we let the unknown ones 
+through---then they are the best we have, and the user's rules file may 
+still know what to do with them (see \cref{LabelsSection}).
+The guard on [[named]] matters:
+[[printf]] with a format but no arguments still prints the format once, 
+which would turn \enquote{no course} into a blank line.
+<<keep only the known courses among [[named]], if there are any>>=
+local nick known=""
+for nick in ${named}; do
+  [[ -n "${COURSE_CODES[$nick]}" ]] && known+="${nick}"$'\n'
+done
+[[ -n "${named}" ]] && printf '%s\n' ${known:-${named}}
+return 0
+@
+
+The candidates for the course are then the named courses, or, only if 
+there are none, the members of the families that the keywords suggest.
+When only keywords identify the course we cannot tell [[prgm]] from 
+[[prgi]] and we output both---old students of [[prgm]] do still write.
+The unquoted [[${named}]] and the [[tr]] both serve the same output 
+format: one nick name per line.
+<<functions>>=
+course_candidates() {
+  local file=$(file_or_stdin "$1")
+  local named=$(named_courses "$file")
+  if [[ -n "${named}" ]]; then
+    echo "${named}"
+  else
+    course_families "$file" | tr ' ' '\n'
+  fi
+}
+@
+
+\subsubsection{From candidates to codes and nick names}
+
+The [[course_code]] function prints the code of each candidate.
+A course we know is looked up in the table; an unknown \emph{code} is its 
+own code and passes through; an unknown \emph{nick name} has no code we 
+could print, so the [[grep]] against [[COURSE_CODE]] drops it.
 Since many might match, we sort the output and remove duplicates.
 Finally, we make a disjunct regex from the output.
 <<functions>>=
 course_code() {
   local file=$(file_or_stdin "$1")
-  (
-    clean "$file" \
-    | grep -Po "${COURSE_CODE}"
-    for nick in $(course_families "$file"); do
-      echo "${COURSE_CODES[$nick]}"
-    done
-  ) | sort -u \
+  local nick
+  for nick in $(course_candidates "$file"); do
+    echo "${COURSE_CODES[$nick]:-${nick}}"
+  done | grep -Px "${COURSE_CODE}" \
+    | sort -u \
     | make_disjunct_regex
 }
 @ If we run this function on the examples we get the following.
@@ -542,21 +644,32 @@ output = subprocess.run(["./edumail", "course_code", "email2.txt"],
                         capture_output=True)
 print_verbatim(output.stdout)
 \end{pycode}
+\Cref{email4} names the course, so the family is not guessed:
+\begin{pycode}
+output = subprocess.run(["./edumail", "course_code", "email4.txt"],
+                        capture_output=True)
+print_verbatim(output.stdout)
+\end{pycode}
+\Cref{email5} names five courses, of which we keep the one that is ours:
+\begin{pycode}
+output = subprocess.run(["./edumail", "course_code", "email5.txt"],
+                        capture_output=True)
+print_verbatim(output.stdout)
+\end{pycode}
 
-The [[course_nick]] function will do exactly the same, but look for the course 
-nick name in the email and output a nickname instead.
-A nick name found by keywords gets the recent-years suffix, since we're 
-guessing the course round the student means (see above).
+The [[course_nick]] function does the same for nick names.
+Each candidate contributes the rounds the student wrote (a [[prgi23]] in 
+the email) and, for a course we know, also the recent rounds.
+The latter is a guess at the course round the student means; usually they 
+omit the year, see below.
 <<functions>>=
 course_nick() {
   local file=$(file_or_stdin "$1")
-  (
-    clean "$file" \
-    | grep -Po "${COURSE_NICK}"
-    for nick in $(course_families "$file"); do
-      echo "${nick}${YEARS_REGEX}"
-    done
-  ) | sort -u \
+  local nick
+  for nick in $(course_candidates "$file"); do
+    [[ -n "${COURSE_CODES[$nick]}" ]] && echo "${nick}${YEARS_REGEX}"
+    clean "$file" | grep -Po "${nick}[0-9]{2}(?![A-Za-z0-9])"
+  done | sort -u \
     | make_disjunct_regex
 }
 @ Running the [[course_nick]] function on the examples yields the following.
@@ -569,6 +682,18 @@ print_verbatim(output.stdout)
 \Cref{email2} yields the following output:
 \begin{pycode}
 output = subprocess.run(["./edumail", "course_nick", "email2.txt"],
+                        capture_output=True)
+print_verbatim(output.stdout)
+\end{pycode}
+\Cref{email4} yields the following output:
+\begin{pycode}
+output = subprocess.run(["./edumail", "course_nick", "email4.txt"],
+                        capture_output=True)
+print_verbatim(output.stdout)
+\end{pycode}
+\Cref{email5} yields the following output:
+\begin{pycode}
+output = subprocess.run(["./edumail", "course_nick", "email5.txt"],
                         capture_output=True)
 print_verbatim(output.stdout)
 \end{pycode}
@@ -678,7 +803,8 @@ print_verbatim(output.stdout)
 \end{pycode}
 This is correct.
 The student gave the course code, but not which course round.
-The student also named some keywords for the programming courses.
+The email also contains keywords for the programming courses, but since the 
+course is named, the family is not guessed and [[prgm]] stays out.
 (The years in the regex are calculated from the current year, when we compile 
 this document, but the email examples are older than that---from when I wrote 
 the first version of this script.
@@ -692,7 +818,8 @@ output = subprocess.run(["./edumail", "course", "email2.txt"],
 print_verbatim(output.stdout)
 \end{pycode}
 This is correct, since the email doesn't contain any course code.
-Infact, \cref{email2} doesn't identify any course at all.
+In fact, \cref{email2} doesn't identify any course at all, so the keyword 
+families are all we have.
 
 
 \section{Extracting assignments}
@@ -1204,9 +1331,21 @@ output = subprocess.run(["./edumail", "results", "email2.txt"],
 print_verbatim(str(output.stdout, "utf-8"))
 \end{pycode}
 
-Finally, running [[results]] on \cref{email3} yields the following output:
+Running [[results]] on \cref{email3} yields the following output:
 \begin{pycode}
 output = subprocess.run(["./edumail", "results", "email3.txt"],
+                        capture_output=True)
+print_verbatim(str(output.stdout, "utf-8"))
+\end{pycode}
+\Cref{email4} names the course, so the course variables are narrowed to it:
+\begin{pycode}
+output = subprocess.run(["./edumail", "results", "email4.txt"],
+                        capture_output=True)
+print_verbatim(str(output.stdout, "utf-8"))
+\end{pycode}
+Finally, \cref{email5} names five courses, of which only ours remains:
+\begin{pycode}
+output = subprocess.run(["./edumail", "results", "email5.txt"],
                         capture_output=True)
 print_verbatim(str(output.stdout, "utf-8"))
 \end{pycode}

--- a/edumail.nw
+++ b/edumail.nw
@@ -1373,42 +1373,39 @@ wrote ([[prgi23]] becomes [[prgi]]).
 We also prefer the nick to the code even when the student wrote the code:
 [[prgi]] rather than [[DD1317]], so that the time lands under the one
 name we use for the course everywhere else in [[nytid]].
-That translation is the [[COURSE_CODES]] table read backwards; a code the
-table doesn't know is a stable name in its own right and passes through
-unchanged (a user's rules file can then map it, see below).
-<<functions>>=
-nick_of_course_code() {
-  local code="${1^^}" nick
-  for nick in "${!COURSE_CODES[@]}"; do
-    if [[ "${COURSE_CODES[$nick]}" == "${code}" ]]; then
-      echo "${nick}"
-      return
-    fi
-  done
-  echo "${code}"
-}
-@
+This is exactly what [[course_candidates]] outputs:
+named courses as nicks, translated by [[nick_of_course_code]], or the
+keyword families when nothing is named.
+When only keywords identify the course we thus get both [[prgm]] and
+[[prgi]]; the concurrent-label model makes that cheap, and the sum for
+either course is still right.
+A code the table doesn't know passes through unchanged (when it is all
+we have), and a user's rules file can then map it, see below.
 
-The families pose a choice.
-When only keywords identify the course, we cannot tell [[prgm]] from
-[[prgi]] and we output both; the concurrent-label model makes that cheap,
-and the sum for either course is still right---and old students of
-[[prgm]] do still write.
-But when the email names a member of the family by code, we output only
-that member:
-a student who writes DD1317 has told us which course they mean, and a
-[[prgm]] label would only be noise.
 Assignment groups are labels too---[[INL1]] and [[LAB2]] are what we
 already track by hand---so we reuse the search from [[assignment_groups]],
 but not the default it falls back on:
 a label must name something the email actually mentions.
+But not every email about a course is about its modules.
+\Cref{email5} is from someone who wants to \emph{be} a teaching
+assistant; such an email, like a teaching assistant's own mail, concerns
+the course as a whole.
+The words in it still hit the module tests (\enquote{rättade
+inlämningsuppgifter} suggests LAB1 for the datintro course) and the
+examination rules (\enquote{rättade} again), and both would be the wrong
+bucket.
+So we test for that kind of email first, and derive the module-level
+labels only when it isn't one.
 <<functions>>=
 labels() {
   local file=$(file_or_stdin "$1")
   (
-    <<emit one label per course>>
-    <<find assignment groups in [[file]]>>
-    labels_rules "$file"
+    course_candidates "$file"
+    if <<test for TA terms>>; then
+      <<labels about the course as a whole>>
+    else
+      <<labels about the course's modules>>
+    fi
   ) | sort -u
 }
 @ Duplicates are expected---a course both named and described by keywords,
@@ -1417,34 +1414,77 @@ sorted output doubles as a canonical form that callers can compare and
 diff against (which [[nymutt]] does to keep timers running across
 consecutive emails about the same course).
 
-The course labels come from three places:
-the families whose keywords match, narrowed by any codes in the email;
-the codes themselves, translated; and the nicks the student wrote, with
-the year removed.
-The [[grep -x]] against the (upper-cased) code list is how a family
-member counts as named; [[${named:-${family}}]] then falls back to the
-whole family when no member was.
-<<emit one label per course>>=
-local codes=$(clean "$file" | grep -Po "${COURSE_CODE}" \
-              | tr '[:lower:]' '[:upper:]' | sort -u)
-local family named nick code
-while read -r family; do
-  named=""
-  for nick in ${family}; do
-    grep -qx "${COURSE_CODES[$nick]}" <<< "${codes}" && named+=" ${nick}"
-  done
-  printf '%s\n' ${named:-${family}}
-done < <(course_families "$file")
-for code in ${codes}; do
-  nick_of_course_code "${code}"
-done
-clean "$file" | grep -Po "${COURSE_NICK}" | sed -E 's/[0-9]{2}$//'
+Emails about the modules get the assignment groups and everything the
+user's rules say (\cref{LabelRules}).
+<<labels about the course's modules>>=
+<<find assignment groups in [[file]]>>
+labels_rules "$file"
 @
 
-\subsection{User-defined label rules}
+Emails about the course as a whole get the [[TA-management]] label
+instead of assignment groups, and the rules' labels minus the
+examination ones.
+Those names are a convention of the seed rules that ship with
+[[nymutt]] (\cref{SeedRules} in its documentation), which attach them to
+module-level matters: grades, Ladok, resubmissions.
+That is why this script may know them; a rules file that uses other
+names for those matters must extend the list.
+The user's own [[TA-management]] rules (timesheets, pay) must spell the
+label as we do here, or the time splits over two labels.
+<<labels about the course as a whole>>=
+echo "TA-management"
+labels_rules "$file" | grep -vxE "${EXAMINATION_LABELS}"
+<<variables>>=
+EXAMINATION_LABELS="examination|grading|ladok"
+@
 
-The course tests above change rarely, so hard-coding them in this script
-is fine.
+\subsection{Recognizing mail about teaching assistants}
+
+The test is a conjunction:
+the email must mention an assistant \emph{and} hint at employment.
+A student writing \enquote{assistenten sa att det var godkänt} is asking
+about a module, and the noun alone cannot tell that email from
+\cref{email5}.
+<<test for TA terms>>=
+   <<look for>> "${TA_NOUN}" \
+&& <<look for>> "${TA_EMPLOYMENT}"
+@
+
+The noun comes in Swedish inflections (\enquote{assistenten},
+\enquote{assistenter}), in the compound \enquote{lärarassistent} that
+applicants write, in the slang forms \enquote{asse} and
+\enquote{assning}, and as \enquote{amanuens}, the title of a student
+employed part time.
+The short forms need word boundaries, or \enquote{asse} would match
+inside far too many words.
+The abbreviation TA needs more:
+we grep case-insensitively, but \enquote{ta} is a verb that opens half
+of all Swedish subject lines, so that alternative opts out of the
+case-insensitivity with PCRE's [[(?-i:...)]].
+<<variables>>=
+TA_NOUN="\b(assning|asse|(lärar)?assistent(en|er|erna)?)\b"
+TA_NOUN="${TA_NOUN}|\bamanuens(en|er|erna)?\b|(?-i:\bTA\b)"
+@
+
+The employment hints are what \cref{email5} offers---\enquote{intresse
+att vara lärarassistent}, \enquote{bli lärarassistent},
+\enquote{praktiktimmar}, \enquote{varit lärarassistent}, \enquote{rollen
+som lärarassistent}---and the obvious work words.
+The verbs \enquote{bli}, \enquote{vara} and the word \enquote{som} are
+everywhere, so they count only directly before the noun.
+\enquote{Timmar} is deliberately not a hint:
+students write about the hours they spent on a lab.
+<<variables>>=
+TA_EMPLOYMENT="\b(jobba|arbeta|anställ|ansök|praktik|intresse|rekryter"
+TA_EMPLOYMENT="${TA_EMPLOYMENT}|arvode|lön\b)"
+TA_EMPLOYMENT="${TA_EMPLOYMENT}|\b(bli|vara|varit|som)\s+(lärar)?assistent"
+TA_EMPLOYMENT="${TA_EMPLOYMENT}|\b(bli|vara|varit|som)\s+amanuens"
+@
+
+\subsection{User-defined label rules}\label{LabelRules}
+
+The course and assistant tests above change rarely, so hard-coding them
+in this script is fine.
 Label rules are different: a new mailing list, an administrative sender, a
 committee---these appear all the time, and the person adding them is in
 their mail client, not in this repository rebuilding the script.
@@ -1542,6 +1582,29 @@ print_verbatim(output.stdout)
 so the email gets the whole family---and the project's assignment group:
 \begin{pycode}
 output = subprocess.run(["./edumail", "labels", "email2.txt"],
+                        capture_output=True, env=norules)
+print_verbatim(output.stdout)
+\end{pycode}
+\Cref{email4} names the course in the body and the module in the subject,
+so it gets just those two:
+\begin{pycode}
+output = subprocess.run(["./edumail", "labels", "email4.txt"],
+                        capture_output=True, env=norules)
+print_verbatim(output.stdout)
+\end{pycode}
+\Cref{email5} is recognized as mail about a teaching assistant:
+of the five courses named only ours remains, and no assignment group is
+derived although the datintro keywords occur in the email:
+\begin{pycode}
+output = subprocess.run(["./edumail", "labels", "email5.txt"],
+                        capture_output=True, env=norules)
+print_verbatim(output.stdout)
+\end{pycode}
+The conjunction in the assistant test is what keeps a student's mention
+of their assistant from being taken for assistant matters:
+\begin{pycode}
+email = "Subject: Re: LAB2\n\nAssistenten sa att det var godkänt.\n"
+output = subprocess.run(["./edumail", "labels"], input=email.encode(),
                         capture_output=True, env=norules)
 print_verbatim(output.stdout)
 \end{pycode}

--- a/edumail.nw
+++ b/edumail.nw
@@ -1488,9 +1488,13 @@ in this script is fine.
 Label rules are different: a new mailing list, an administrative sender, a
 committee---these appear all the time, and the person adding them is in
 their mail client, not in this repository rebuilding the script.
-So the remaining rules live in a configuration file,
+So the remaining rules live in a configuration file, whose location
+can be overridden from the environment---to try a rules file before
+installing it, and for [[nymutt]]'s documentation to demonstrate its
+seed rules without touching the author's own file,
 <<variables>>=
-LABELS_RULES="${XDG_CONFIG_HOME:-$HOME/.config}/edumail/labels.rules"
+DEFAULT_RULES="${XDG_CONFIG_HOME:-$HOME/.config}/edumail/labels.rules"
+LABELS_RULES="${LABELS_RULES:-${DEFAULT_RULES}}"
 @ with one rule per line:
 a pattern, whitespace, and the labels that pattern maps to.
 A [[#]] starts a comment.

--- a/email4.txt
+++ b/email4.txt
@@ -1,0 +1,35 @@
+Date: Tue, 1 Sep 2026 09:33:28 +0200
+From: Daniel Bosk <dbosk@kth.se>
+To: Studenten Studentensson <studenten@kth.se>
+Subject: Re: LAB3
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset=utf-8
+
+On Tue Sep  1 09:07:47 2026, Studenten Studentensson wrote:
+> Hej Daniel!
+> 
+> 
+> Jag gjorde komplettering av labbredovisningen i kursen DD1317 nu under sommaren
+> och har fortfarande inte fått mitt betyg. Jag har bytt skola och program så
+> hade varit jättebra om det hade kunnat registreras så snart som möjligt. Jag
+> har lite krångel att komma in i Canvas just nu.
+> 
+> 
+> Med vänliga hälsningar
+> 
+> 
+> Studenten Studentensson 
+> 
+> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+> 
+> Observera att avsändaren inte är anställd vid Kungliga Tekniska högskolan. KTH
+> ansvarar inte för åsikter, påståenden eller personuppgifter som förmedlas i
+> detta meddelande.
+> 
+> Please note that the sender is not employed by KTH Royal Institute of
+> Technology. KTH is not responsible for the opinions, claims or personal data
+> conveyed in this message.
+> 
+
+

--- a/email5.txt
+++ b/email5.txt
@@ -1,0 +1,46 @@
+Date: Tue, 1 Sep 2026 10:08:56 +0200
+From: Daniel Bosk <dbosk@kth.se>
+To: Studenten Studentensdotter <sdotter@kth.se>
+Subject: Re: Intresse att vara lärarassistent i DD1301
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset=utf-8
+
+On Tue Feb 10 11:27:56 2026, Studenten Studentensdotter wrote:
+> Hej Daniel!
+> 
+> 
+> Jag skriver för att höra om det finns möjlighet att bli lärarassistent i kursen
+> Datorintroduktion (DD1301) under period 4. 
+> 
+> 
+> Jag går årskurs 3 på datorteknik, och går just nu Hulda-kursen (DA1700), där
+> jag har avslutat mina praktiktimmar. Under praktiken hjälpte jag främst till i
+> kursen Programmeringsteknik (DD1319) och i viss mån tillämpad datalogi
+> (DD1320). Jag har även varit lärarassistent i kursen DD1368, där jag främst
+> rättade inlämningsuppgifter. 
+> 
+> 
+> Jag skulle väldigt gärna vilja bidra även i DD1301 och fortsätta utvecklas i
+> rollen som lärarassistent. 
+> 
+> 
+> Tack på förhand!
+> 
+> 
+> Vänliga hälsningar,
+> 
+> Studenten Studentensdotter
+> 
+> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+> 
+> Observera att avsändaren inte är anställd vid Kungliga Tekniska högskolan. KTH
+> ansvarar inte för åsikter, påståenden eller personuppgifter som förmedlas i
+> detta meddelande.
+> 
+> Please note that the sender is not employed by KTH Royal Institute of
+> Technology. KTH is not responsible for the opinions, claims or personal data
+> conveyed in this message.
+> 
+
+

--- a/nymutt.nw
+++ b/nymutt.nw
@@ -902,8 +902,8 @@ DA231X|exjobb|master.*thesis                        exjobb supervision
 
 \subsection{Topics}
 
-The topic rules reuse the labels we already track by hand---[[grading]],
-[[ladok]], [[restlabb]], [[TA-management]], [[reporting]],
+The topic rules reuse the labels we already track by hand---[[ladok]],
+[[examination]], [[restlabb]], [[TA-management]], [[reporting]],
 [[meeting]]---so that email time lands in the same buckets as the rest
 of the work on that topic.
 Several rules carry two labels for the same reason:
@@ -912,6 +912,11 @@ the concurrent-label model costs nothing for saying so.
 The grading-related rules (Ladok, grades, resubmissions, examination,
 credit transfer, CSN) are unprefixed for the same reason as the course
 rules: they come from students, who put the matter in the body.
+They label the email [[examination]], not [[grading]]:
+a student asking about a grade, a Ladok entry or a resubmission is
+examination administration, whereas [[grading]] is the time spent
+grading, which we track by hand (and through the Urkund stream
+below)---mixing the two would inflate it.
 Here too the body forces a tighter pattern:
 [[rester]] alone would match the everyday \enquote{resterande}, so
 resubmissions are [[rest(er\b|labb|uppgift|inlämn)]].
@@ -923,9 +928,9 @@ in running text to be labels on their own.
 subject:ti[dm]s?(rapport|ersättning)|time\s?sheet   reporting TA-management
 subject:lön|timmar|arvode                           reporting TA-management
 subject:\b(assning|asse|assistent)\b|(?-i:\bTA\b)   TA-management
-ladok|betyg                                         ladok grading examination
-kompletter(a|ing)|rätt(ad?|ning)                    grading examination
-redovis(a|ning)                                     grading examination
+ladok|betyg                                         ladok examination
+kompletter(a|ing)|rätt(ad?|ning)                    examination
+redovis(a|ning)                                     examination
 examin(era|ation)                                   examination
 \brest(er\b|labb|uppgift|inlämn)                    restlabb examination
 (?-i:\bCSN\b)                                       csn examination

--- a/nymutt.nw
+++ b/nymutt.nw
@@ -56,7 +56,8 @@ def print_verbatim(output):
 
 demoenv = dict(os.environ,
                EDUMAIL="./edumail",
-               XDG_CONFIG_HOME="/nonexistent")
+               XDG_CONFIG_HOME="/nonexistent",
+               LABELS_RULES="labels.rules")
 \end{pycode}
 
 @
@@ -291,14 +292,36 @@ derive() {
 
 This is also the testing entry point, since it's the only subcommand
 with no side effects.
-Running it on [[edumail]]'s example emails:
+Running it on [[edumail]]'s example emails, with the seed rules from
+\cref{SeedRules} as the rules file (we point [[XDG_CONFIG_HOME]] away
+from the author's personal rules file and [[LABELS_RULES]] at the file
+tangled from this document):
 \begin{pycode}
 output = subprocess.run(["./nymutt", "derive", "email1.txt"],
                         capture_output=True, env=demoenv)
 print_verbatim(output.stdout)
 \end{pycode}
-(As in the [[edumail]] documentation, we point [[XDG_CONFIG_HOME]] away
-from the author's personal rules file when compiling this document.)
+Here [[edumail]] contributes [[prgi]]; the seed rules add [[restlabb]],
+[[examination]] and [[ladok]] from the student's words (\enquote{restlabb},
+\enquote{redovisade}, \enquote{Ladok}).
+The fourth example, a student who names the course and asks about a
+missing grade, works the same way:
+\begin{pycode}
+output = subprocess.run(["./nymutt", "derive", "email4.txt"],
+                        capture_output=True, env=demoenv)
+print_verbatim(output.stdout)
+\end{pycode}
+The fifth is an application to become a teaching assistant.
+[[edumail]] recognizes it as such and then leaves out the module-level
+labels, its own assignment groups as well as the rules'
+[[examination]]---the applicant's \enquote{rättade} would otherwise
+have matched---while a course the rules know ([[tilda]], from DD1320 in
+the applicant's experience) is kept:
+\begin{pycode}
+output = subprocess.run(["./nymutt", "derive", "email5.txt"],
+                        capture_output=True, env=demoenv)
+print_verbatim(output.stdout)
+\end{pycode}
 
 \subsection{Opening an email}
 

--- a/nymutt.nw
+++ b/nymutt.nw
@@ -758,8 +758,9 @@ Swedish verb \enquote{ta}, which opens half of all Swedish subject lines.
 [[edumail]] always greps with [[-i]], so a naive translation would put
 [[TA-management]] on most of the inbox.
 PCRE lets a group opt out of the outer flag, [[(?-i:...)]], and every
-all-caps token below (TA, CSN, LAB1, the programme codes, the learned
-societies) is wrapped that way.
+all-caps token below (CSN, KAL1, the programme codes, the learned
+societies) is wrapped that way---as is the TA in [[edumail]]'s own
+assistant test, where that rule now lives (see below).
 
 Not everything in the scoring file names a topic.
 Rules on age, flags and urgency words rank emails without saying what
@@ -767,8 +768,10 @@ they are about, and domain-wide rules (anything from a Swedish
 university) would put a label on nearly every email; both kinds are left
 out.
 So are the courses that [[edumail labels]] already recognises by keyword
-(programming, datintro, crypto, science):
-the seed only adds the courses it does not.
+(programming, datintro, crypto, science), and mail about teaching
+assistants, which it recognises itself so that it can leave the module
+labels out of such mail:
+the seed only adds what it does not.
 
 The file opens with the format reminder from the original one-line seed.
 <<[[labels.rules]]>>=
@@ -909,6 +912,10 @@ of the work on that topic.
 Several rules carry two labels for the same reason:
 a timesheet from a TA is both [[reporting]] and [[TA-management]], and
 the concurrent-label model costs nothing for saying so.
+The [[TA-management]] label is spelled as [[edumail]] spells it, since
+[[edumail]] emits it itself for mail about teaching assistants; the
+rules here only add the cases it can't see, timesheets and pay.
+
 The grading-related rules (Ladok, grades, resubmissions, examination,
 credit transfer, CSN) are unprefixed for the same reason as the course
 rules: they come from students, who put the matter in the body.
@@ -927,7 +934,6 @@ in running text to be labels on their own.
 # topics
 subject:ti[dm]s?(rapport|ersättning)|time\s?sheet   reporting TA-management
 subject:lön|timmar|arvode                           reporting TA-management
-subject:\b(assning|asse|assistent)\b|(?-i:\bTA\b)   TA-management
 ladok|betyg                                         ladok examination
 kompletter(a|ing)|rätt(ad?|ning)                    examination
 redovis(a|ning)                                     examination

--- a/preamble.tex
+++ b/preamble.tex
@@ -1,4 +1,8 @@
 \usepackage[utf8]{inputenc}
+% The example emails carry KTH's disclaimer, separated by a line of heavy
+% horizontal box-drawing characters (U+2501), which pdfLaTeX has no glyph
+% for; typeset each as a short rule.
+\DeclareUnicodeCharacter{2501}{\rule{0.5em}{0.12ex}}
 \usepackage[T1]{fontenc}
 \usepackage[swedish,british]{babel}
 


### PR DESCRIPTION
Two new example emails (`email4.txt`, `email5.txt`) exposed weaknesses in how `edumail` picks the course and derives time-tracking labels.

## Course detection
- **Named beats guessed**: keyword families (prgm/prgi) are only guessed when the email names no course. An email naming DD1317 now yields `(DD1317)` / `(prgi(24|25|26))` instead of the whole family.
- **Known beats unknown**: among named courses, the ones in `COURSE_CODES` win, so a TA application listing five codes yields only `(DD1301)`.
- `nick_of_course_code` moves next to the table it inverts; `labels` builds on the same `course_candidates`.

## Labels
- Built-in test for mail about teaching assistants (assistent inflections, lärarassistent, asse/assning, amanuens, `TA`) **and** an employment hint; such mail gets `TA-management` and no assignment groups or examination/grading/ladok labels. "Assistenten sa att det var godkänt" does not count.
- `LABELS_RULES` can be overridden from the environment.

## Seed rules (nymutt)
- Student grade/Ladok/resubmission questions are `examination`, not `grading`.
- The TA subject rule is dropped (edumail owns it); timesheet/pay rules keep `TA-management`.
- `derive` demos run with the tangled seed rules; `nymutt.pdf` depends on `labels.rules`.

## Build
- `preamble.tex` declares U+2501 (KTH disclaimer separator) for pdfLaTeX.

Verified: both PDFs build; `edumail`/`nymutt` outputs on all five example emails match the expectations in the documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oDDB9YZZMpfFUye31fBJh