### PR TITLE
Add a stream: rule prefix and recognize assistant mail on amanuens

### DIFF
--- a/edumail.nw
+++ b/edumail.nw
@@ -1440,6 +1440,36 @@ EXAMINATION_LABELS="examination|grading|ladok"
 
 \subsection{Recognizing mail about teaching assistants}
 
+Three emails from one thread show what such mail looks like from our
+side of it: we ask for a contract, the assistant answers, and the
+personnel office answers.
+\begin{example}\label{email6}
+We ask the personnel office for an assistant's contract, as a
+tab-separated line: identifier, name and address, first and last day,
+percentage.
+\inputminted[highlightlines={3,5,13,15}]{text}{email6.txt}
+Nothing here names a course, and the only word about the employment is
+the compound \enquote{amanuensavtal}.
+\end{example}
+\begin{example}\label{email7}
+The assistant replies that the percentage is too high.
+\inputminted[highlightlines={2,4,11}]{text}{email7.txt}
+The reply says \enquote{rättat till} about their bookings, which the
+rules of \cref{LabelRules} would take for grading.
+\end{example}
+\begin{example}\label{email8}
+The personnel office replies to us and a colleague, who both asked for
+a contract with the same assistant, because the two add up to more
+than the allowed 50\%.
+\inputminted[highlightlines={2,5,12-14}]{text}{email8.txt}
+The words are employment words---\enquote{timanställning},
+\enquote{amanuenstjänsten}, \enquote{jobba på timme}---and the sender
+is a support desk.
+\end{example}
+All three are about the assistant's employment and none about a module
+of the course; which course it is the thread never says, so no course
+can be derived from it.
+
 The test is a conjunction:
 the email must mention an assistant \emph{and} hint at employment.
 A student writing \enquote{assistenten sa att det var godkänt} is asking
@@ -1457,13 +1487,18 @@ applicants write, in the slang forms \enquote{asse} and
 employed part time.
 The short forms need word boundaries, or \enquote{asse} would match
 inside far too many words.
+\enquote{Amanuens} needs the opposite, a boundary in front only:
+it is the head of the compounds that contract mail is written
+in---\enquote{amanuensavtal}, \enquote{amanuensanställning},
+\enquote{amanuenstjänst}---and \cref{email6} consists of little else.
+No other Swedish word starts that way, so the bare stem is safe.
 The abbreviation TA needs more:
 we grep case-insensitively, but \enquote{ta} is a verb that opens half
 of all Swedish subject lines, so that alternative opts out of the
 case-insensitivity with PCRE's [[(?-i:...)]].
 <<variables>>=
 TA_NOUN="\b(assning|asse|(lärar)?assistent(en|er|erna)?)\b"
-TA_NOUN="${TA_NOUN}|\bamanuens(en|er|erna)?\b|(?-i:\bTA\b)"
+TA_NOUN="${TA_NOUN}|\bamanuens|(?-i:\bTA\b)"
 @
 
 The employment hints are what \cref{email5} offers---\enquote{intresse
@@ -1474,11 +1509,17 @@ The verbs \enquote{bli}, \enquote{vara} and the word \enquote{som} are
 everywhere, so they count only directly before the noun.
 \enquote{Timmar} is deliberately not a hint:
 students write about the hours they spent on a lab.
+\enquote{Amanuens} is a hint by itself:
+where \enquote{assistent} is what a student calls the person who graded
+their lab, \enquote{amanuens} is a job title, so an email that uses it
+is about the employment---\cref{email6} asks for a contract in a single
+line with no other work word in it.
+The word is therefore in both lists and carries the test alone.
 <<variables>>=
 TA_EMPLOYMENT="\b(jobba|arbeta|anställ|ansök|praktik|intresse|rekryter"
 TA_EMPLOYMENT="${TA_EMPLOYMENT}|arvode|lön\b)"
 TA_EMPLOYMENT="${TA_EMPLOYMENT}|\b(bli|vara|varit|som)\s+(lärar)?assistent"
-TA_EMPLOYMENT="${TA_EMPLOYMENT}|\b(bli|vara|varit|som)\s+amanuens"
+TA_EMPLOYMENT="${TA_EMPLOYMENT}|\bamanuens"
 @
 
 \subsection{User-defined label rules}\label{LabelRules}
@@ -1612,6 +1653,20 @@ output = subprocess.run(["./edumail", "labels"], input=email.encode(),
                         capture_output=True, env=norules)
 print_verbatim(output.stdout)
 \end{pycode}
+The contract thread (\cref{email6,email7,email8}) is recognized on the
+word \enquote{amanuens} alone, and yields nothing else:
+no course is named, no module mentioned, and without a rules file there
+is nothing for the examination filter to remove.
+\begin{pycode}
+lines = []
+for email in ["email6.txt", "email7.txt", "email8.txt"]:
+    output = subprocess.run(["./edumail", "labels", email],
+                            capture_output=True, env=norules)
+    lines.append(f"{email}: " + " ".join(output.stdout.decode().split()))
+print_verbatim("\n".join(lines))
+\end{pycode}
+What the rules add to the thread is shown with the seed rules in the
+[[nymutt]] documentation.
 An email matching neither a course test nor a rule yields nothing at all;
 it's the caller's job to fall back to something sensible---[[nymutt]]
 always adds a base [[email]] label of its own.

--- a/edumail.nw
+++ b/edumail.nw
@@ -1457,7 +1457,7 @@ Emails about the course as a whole get the [[TA-management]] label
 instead of assignment groups, and the rules' labels minus the
 examination ones.
 Those names are a convention of the seed rules that ship with
-[[nymutt]] (\cref{SeedRules} in its documentation), which attach them to
+[[nymutt]] (the seed rules section of its documentation), which attach them to
 module-level matters: grades, Ladok, resubmissions.
 That is why this script may know them; a rules file that uses other
 names for those matters must extend the list.

--- a/edumail.nw
+++ b/edumail.nw
@@ -864,6 +864,11 @@ here---once, since [[course]] is the expensive part of this script and the
 tests below would otherwise each run it again.
 <<find assignment groups in [[file]]>>=
 local courses=$(course "$file")
+<<literal assignment groups in [[file]]>>
+@ The literal search is a chunk of its own because it is also all that
+mail from a program gets (\cref{LabelsSection}): what such mail names it
+means, but its words are not to be guessed from.
+<<literal assignment groups in [[file]]>>=
 clean "$file" \
 | grep -Po "${ASSIGNMENT_GROUP}" \
 | grep -Pv "${COURSE_CODE}"
@@ -1396,15 +1401,42 @@ examination rules (\enquote{rättade} again), and both would be the wrong
 bucket.
 So we test for that kind of email first, and derive the module-level
 labels only when it isn't one.
+
+One distinction comes before even that.
+The keyword families and the module tests are guesses from words, made
+for students who describe a course rather than name it---mail written
+by people.
+Mail written by programs uses the same words for other reasons.
+\begin{example}\label{email9}
+A cron job reports that the nightly backup failed.
+\inputminted[highlightlines={2,4,9}]{text}{email9.txt}
+The word \enquote{ssh} is what a datintro student writes about, and
+here it occurs three times.
+\end{example}
+Guessed from its words, \cref{email9} is a datintro email, module and
+all; a GitHub notification fares no better, since \enquote{git} is in
+its sender's name.
+What a program \emph{states} is evidence all the same:
+a script that reports grades names the course code and the assignment
+group it reported.
+So for such mail we keep what is stated literally and what the rules
+say, and skip the guesses.
+Which senders are programs is nothing this script can know---the list
+changes with every tool we adopt---so the rules file says so, with a
+[[stream:]] rule (\cref{LabelRules}).
 <<functions>>=
 labels() {
   local file=$(file_or_stdin "$1")
   (
-    course_candidates "$file"
-    if <<test for TA terms>>; then
-      <<labels about the course as a whole>>
+    if is_stream "$file"; then
+      <<labels from what a stream states>>
     else
-      <<labels about the course's modules>>
+      course_candidates "$file"
+      if <<test for TA terms>>; then
+        <<labels about the course as a whole>>
+      else
+        <<labels about the course's modules>>
+      fi
     fi
   ) | sort -u
 }
@@ -1436,6 +1468,19 @@ echo "TA-management"
 labels_rules "$file" | grep -vxE "${EXAMINATION_LABELS}"
 <<variables>>=
 EXAMINATION_LABELS="examination|grading|ladok"
+@
+
+Mail from a program gets what it states and what the rules say.
+The named courses are the ones [[course_candidates]] would have found;
+what is left out is its fallback to the keyword families, and the
+module tests, which guess from the same words.
+The literal assignment groups stay, since a program that prints
+[[LAB1]] means it.
+There is no assistant test either: a program does not apply for a job.
+<<labels from what a stream states>>=
+named_courses "$file"
+<<literal assignment groups in [[file]]>>
+labels_rules "$file"
 @
 
 \subsection{Recognizing mail about teaching assistants}
@@ -1544,10 +1589,20 @@ field to restrict where it must match:
 [[from:]] matches only the \enquote{From: } header (this is how senders
 become labels), [[subject:]] only the \enquote{Subject: } header, and no
 prefix matches anywhere in the cleaned email.
+A fourth prefix, [[stream:]], matches the \enquote{From: } header like
+[[from:]] and says one thing more: the sender is a program.
+For an email a [[stream:]] rule matches, [[labels]] skips its keyword
+guesses and keeps only what the email states literally and what the
+rules say (\cref{email9} shows why); such a rule may even carry no
+labels, when that is all there is to say.
+The prefix is deliberately not [[from:]] with a side effect:
+a rule for a person is a [[from:]] rule, a rule for a tool is a
+[[stream:]] rule, and the file shows which is which.
 For example:
 \begin{minted}{text}
 # pattern                      labels
 from:.*@ug\.kth\.se            admin
+stream:Cron\sDaemon            admin
 exjobb|thesis                  supervision exjobb
 \end{minted}
 
@@ -1557,20 +1612,42 @@ This gives a trivially simple format at the price that a pattern cannot
 contain literal whitespace---use [[\s]] in the regex instead.
 Every matching rule contributes its labels; an email about two things gets
 both sets, which is exactly what concurrent time tracking wants.
+The rules answer two questions, though---which labels, and whether a
+[[stream:]] rule matched---and both need the same walk through the
+file.
+Rather than two loops that each know the prefixes, one function reports
+every matching rule as its field followed by its labels, and each
+question is a thin reading of that report.
 <<functions>>=
-labels_rules() {
+matching_rules() {
   local file=$(file_or_stdin "$1")
   [[ -r "${LABELS_RULES}" ]] || return 0
   local pattern rule_labels field
   while read -r pattern rule_labels; do
     <<skip comments and blank lines>>
     <<split any [[field]] prefix off [[pattern]]>>
-    <<emit [[rule_labels]] if [[pattern]] matches [[field]]>>
+    <<report the rule if [[pattern]] matches [[field]]>>
   done < "${LABELS_RULES}"
 }
 @ A missing rules file is not an error:
 the course tests alone are a useful default, and [[nymutt]] must keep
 working on a machine where no rules have been written yet.
+
+The labels are everything after the field, one per line as [[labels]]
+prints them; [[cut -s]] drops a report line with no labels rather than
+printing its field.
+The stream question is answered by the field alone, matched as a whole
+word so that a label-less [[stream]] line counts too.
+<<functions>>=
+labels_rules() {
+  local file=$(file_or_stdin "$1")
+  matching_rules "$file" | cut -s -d' ' -f2- | tr ' ' '\n'
+}
+is_stream() {
+  local file=$(file_or_stdin "$1")
+  matching_rules "$file" | grep -qw '^stream'
+}
+@
 
 A comment line's first word starts with [[#]], and on a blank line
 [[read]] leaves the pattern empty.
@@ -1580,13 +1657,14 @@ A comment line's first word starts with [[#]], and on a blank line
 
 The field prefix is split off with shell prefix removal rather than
 parsed with a regex:
-a colon is legal in a regex, so we only treat the two known prefixes
+a colon is legal in a regex, so we only treat the three known prefixes
 specially and let anything else---including a pattern that happens to
 start with [[http:]]---fall through as a whole-email pattern.
 <<split any [[field]] prefix off [[pattern]]>>=
 field=any
 case "${pattern}" in
   from:*)    field=from;    pattern="${pattern#from:}";;
+  stream:*)  field=stream;  pattern="${pattern#stream:}";;
   subject:*) field=subject; pattern="${pattern#subject:}";;
 esac
 @
@@ -1596,16 +1674,19 @@ case-insensitive Perl grep as the course tests.
 The header fields are matched against the raw email, not the cleaned one:
 [[clean]] exists to stop \emph{body} keywords from matching noise headers,
 but a [[from:]] rule wants exactly a header line.
-The unquoted [[${rule_labels}]] in [[printf]] is deliberate:
-word splitting turns the rule's labels into one argument each, which
-[[printf]] then prints one per line, the output format of [[labels]].
-<<emit [[rule_labels]] if [[pattern]] matches [[field]]>>=
+A [[stream:]] rule searches that same line; its extra meaning is read
+off the field name by [[is_stream]], not acted on here.
+The unquoted [[${rule_labels}]] in [[echo]] is deliberate:
+word splitting collapses whatever whitespace separated the labels in
+the file to single spaces, so the report has a fixed shape that [[cut]]
+can take apart.
+<<report the rule if [[pattern]] matches [[field]]>>=
 case "${field}" in
-  from)    grep -i "^From: "    "$file";;
-  subject) grep -i "^Subject: " "$file";;
-  any)     clean "$file";;
+  from|stream) grep -i "^From: "    "$file";;
+  subject)     grep -i "^Subject: " "$file";;
+  any)         clean "$file";;
 esac | grep -qiP "${pattern}" \
-  && printf '%s\n' ${rule_labels}
+  && echo "${field}" ${rule_labels}
 @
 
 \subsection{Testing on the emails}
@@ -1667,6 +1748,31 @@ print_verbatim("\n".join(lines))
 \end{pycode}
 What the rules add to the thread is shown with the seed rules in the
 [[nymutt]] documentation.
+
+\Cref{email9} shows the guesses at work on a program's output, and what
+a [[stream:]] rule does about them.
+With no rules, the cron job's \enquote{ssh} makes it a datintro email,
+module and all:
+\begin{pycode}
+output = subprocess.run(["./edumail", "labels", "email9.txt"],
+                        capture_output=True, env=norules)
+print_verbatim(output.stdout)
+\end{pycode}
+A [[from:]] rule for the daemon adds its label and changes nothing else,
+whereas the same rule as a [[stream:]] rule also takes the guesses away:
+\begin{pycode}
+import tempfile
+lines = []
+for prefix in ["from", "stream"]:
+    rules = tempfile.NamedTemporaryFile("w", suffix=".rules", delete=False)
+    rules.write(f"{prefix}:Cron\\sDaemon  admin\n")
+    rules.close()
+    output = subprocess.run(["./edumail", "labels", "email9.txt"],
+                            capture_output=True,
+                            env=dict(norules, LABELS_RULES=rules.name))
+    lines.append(f"{prefix}: " + " ".join(output.stdout.decode().split()))
+print_verbatim("\n".join(lines))
+\end{pycode}
 An email matching neither a course test nor a rule yields nothing at all;
 it's the caller's job to fall back to something sensible---[[nymutt]]
 always adds a base [[email]] label of its own.

--- a/email6.txt
+++ b/email6.txt
@@ -1,0 +1,19 @@
+Date: Mon, 24 Aug 2026 22:53:18 +0200
+From: Daniel Bosk <dbosk@kth.se>
+To: hr-support@eecs.kth.se
+Cc: teknologen@kth.se
+Subject: amanuensavtal Teknologen Teknologsson
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset=utf-8
+
+
+Hej!
+
+Jag vill ha ett amanuensavtal för Teknologen:
+
+200001010000 Teknologen Teknologsson <teknologen@kth.se>	2026-08-24	2026-10-25	29%
+
+        Tack så mycket!
+
+            Daniel

--- a/email7.txt
+++ b/email7.txt
@@ -1,0 +1,28 @@
+Date: Tue, 25 Aug 2026 03:14:11 +0200
+From: Teknologen Teknologsson <teknologen@kth.se>
+To: Daniel Bosk <dbosk@kth.se>
+Subject: Re: amanuensavtal Teknologen Teknologsson
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset=utf-8
+
+Hej!
+
+Jag var lite sen med att få mitt schema och nu har rättat till mina bokningar efter tider då jag kan och jag tror inte att jag kommer kunna jobba 29%.
+
+Mvh,
+Teknologen
+
+> On 24 Aug 2026, at 22:53, Daniel Bosk <dbosk@kth.se> wrote:
+> 
+> 
+> Hej!
+> 
+> Jag vill ha ett amanuensavtal för Teknologen:
+> 
+> 200001010000 Teknologen Teknologsson <teknologen@kth.se>	2026-08-24	2026-10-25	29%
+> 
+>        Tack så mycket!
+> 
+>            Daniel
+> 

--- a/email8.txt
+++ b/email8.txt
@@ -1,0 +1,38 @@
+Date: Tue, 1 Sep 2026 10:03:44 +0200
+From: "hr-support@eecs.kth.se" <hr-support@eecs.kth.se>
+To: Daniel Bosk <dbosk@kth.se>, Kollegan Kollegasson <kollegan@kth.se>
+CC: Teknologen Teknologsson <teknologen@kth.se>
+Subject: RE: amanuensavtal Teknologen Teknologsson
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset=utf-8
+
+Hej Daniel och Kollegan!
+
+Jag har enligt underlag för Teknologen fått in från er 29% för Daniel och 30% för Kollegan.
+Då detta överstiger 50% som är max så får det bli en timanställning utöver de 50%
+Antingen kör vi på 50% och att pratar ni ihop er och meddelar Teknologen för vad han ska rapportera timmar och vad som ska ingå i amanuenstjänsten. Det andra alternativet är att han får jobba på timme för en utav er.
+Låt mig veta hur ni vill göra.
+
+
+Hälsningar,
+Handläggaren
+
+
+-----Original Message-----
+From: Daniel Bosk <dbosk@kth.se> 
+Sent: den 24 augusti 2026 22:53
+To: hr-support@eecs.kth.se
+Cc: Teknologen Teknologsson <teknologen@kth.se>
+Subject: amanuensavtal Teknologen Teknologsson
+
+
+Hej!
+
+Jag vill ha ett amanuensavtal för Teknologen:
+
+200001010000 Teknologen Teknologsson <teknologen@kth.se>	2026-08-24	2026-10-25	29%
+
+        Tack så mycket!
+
+            Daniel

--- a/email9.txt
+++ b/email9.txt
@@ -1,0 +1,17 @@
+Date: Tue, 01 Sep 2026 16:00:01 +0200 (CEST)
+From: Cron Daemon <root@laptop.example.org>
+To: dbosk@laptop.example.org
+Subject: Cron <dbosk@laptop> ${HOME}/.backup
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset=utf-8
+
+ssh: connect to host server.example.org port 22: Connection refused
+rsync: connection unexpectedly closed (0 bytes received so far) [sender]
+rsync error: unexplained error (code 255) at io.c(232) [sender=3.4.1]
+ssh: connect to host server.example.org port 22: Connection refused
+rsync: connection unexpectedly closed (0 bytes received so far) [sender]
+rsync error: unexplained error (code 255) at io.c(232) [sender=3.4.1]
+ssh: connect to host server.example.org port 22: Connection refused
+rsync: connection unexpectedly closed (0 bytes received so far) [sender]
+rsync error: unexplained error (code 255) at io.c(232) [sender=3.4.1]

--- a/nymutt.nw
+++ b/nymutt.nw
@@ -340,6 +340,15 @@ for email in ["email6.txt", "email7.txt", "email8.txt"]:
     lines.append(f"{email}: " + " ".join(output.stdout.decode().split()))
 print_verbatim("\n".join(lines))
 \end{pycode}
+The ninth example is a cron job's output.
+Guessed from its words it would be datintro mail, on the strength of
+\enquote{ssh}; the seed's [[stream:]] rule for the cron daemon keeps
+the guess out and labels the reading as administration:
+\begin{pycode}
+output = subprocess.run(["./nymutt", "derive", "email9.txt"],
+                        capture_output=True, env=demoenv)
+print_verbatim(output.stdout)
+\end{pycode}
 
 \subsection{Opening an email}
 
@@ -791,6 +800,12 @@ The semantics shift from [[mutt]]'s \enquote{sent by} to \enquote{a
 party to}, which is what time tracking wants anyway:
 writing to a teaching assistant is TA work too.
 The same holds for [[mutt]]'s own recipient patterns ([[~t]], [[~c]]).
+The third prefix, [[stream:]], is for senders that are programs:
+it matches the sender line like [[from:]] and, in addition, tells
+[[edumail]] not to guess courses from the words of that email but to
+take only what it states literally and what the rules say (its
+documentation shows why).
+Every automated sender in the scoring file becomes such a rule below.
 
 One difference is easy to miss.
 [[mutt]] matches case-insensitively \emph{unless} the pattern contains an
@@ -821,9 +836,10 @@ The file opens with the format reminder from the original one-line seed.
 #
 #   [field:]PCRE<whitespace>label...
 #
-# field is from, subject or any (the default: anywhere in the
-# cleaned email).  Patterns are case-insensitive Perl regexes and
-# cannot contain whitespace; use \s instead.
+# field is from, stream (a program as sender: no keyword guesses),
+# subject or any (the default: anywhere in the cleaned email).
+# Patterns are case-insensitive Perl regexes and cannot contain
+# whitespace; use \s instead.
 @
 
 \subsection{People}
@@ -984,6 +1000,17 @@ resubmissions are [[rest(er\b|labb|uppgift|inlämn)]].
 The remaining topics keep the [[subject:]] prefix; words like
 \enquote{timmar}, \enquote{sjuk} or \enquote{fråga} are far too common
 in running text to be labels on their own.
+Cron mail is the one sender-based rule among the topics, and it is a
+[[stream:]] rule:
+reading a job's output is administration whatever the job printed, and
+the words it printed must not be guessed from---a failed backup's
+\enquote{ssh: connect to host} is exactly what a student's datintro
+question looks like.
+What the output states still counts, so a job that reports grades to
+Ladok names its course and gets the Ladok rule below.
+The jobs on one host are our own scripts on top of that; that rule is
+on the subject and needs no prefix of its own.
+Calendly and the survey tool are programs too, hence [[stream:]].
 <<[[labels.rules]]>>=
 # topics
 subject:ti[dm]s?(rapport|ersättning)|time\s?sheet   reporting TA-management
@@ -998,23 +1025,30 @@ tillgodoräk                                         tillgodo admin
 subject:kurs-?(analys|pm|(ut)?värdering)            course-admin
 subject:TEL.(meeting|möte)                          tel meeting
 subject:cerise                                      cerise
+stream:Cron\sDaemon                                 admin
 subject:cron.*dbosk@rpi                             admin scripts
-from:Calendly                                       meeting
+stream:Calendly                                     meeting
 subject:receipt\sfrom\sAnthropic                    expenses admin
 subject:(reviewer.*invitation|invitation.*reviewer) reviewing research
-from:KTH\sSurvey                                    survey
+stream:KTH\sSurvey                                  survey
 @
 
 Notification streams from tools are labelled by the tool, since the
 tool usually implies the activity: Canvas and FeedbackFruits mean
 teaching, GitHub means development, Urkund means grading.
+They are [[stream:]] rules, so [[edumail]] does not guess at them:
+a notification quotes commit messages, assignment names and chat lines,
+and GitHub's very name contains \enquote{git}, a datintro keyword, so
+without the prefix every GitHub notification would be datintro mail.
+What a notification names---a course code, an assignment group---is
+still taken literally, which is what we want from Canvas.
 <<[[labels.rules]]>>=
 # tools and notification streams
-from:Canvas|notifications@instructure\.com          canvas
-from:feedbackfruits                                 feedbackfruits canvas
-from:GitHub|notifications@github\.com               devel
-from:Zulip                                          zulip
-from:noreply@urkund\.se                             urkund grading
+stream:Canvas|notifications@instructure\.com        canvas
+stream:feedbackfruits                               feedbackfruits canvas
+stream:GitHub|notifications@github\.com             devel
+stream:Zulip                                        zulip
+stream:noreply@urkund\.se                           urkund grading
 subject:SIGCSE-members                              mailinglist CSE
 @
 
@@ -1025,18 +1059,20 @@ alerts and society mailings.
 Skimming them still costs time, so they get a label rather than none,
 and the digests that feed literature awareness get [[research]] too, so
 that this time is counted where it belongs.
+They are [[stream:]] rules as well: a digest that mentions Python or a
+project is not about our programming course.
 The society acronyms are matched case-sensitively; [[acm]] and
 [[sans]] are substrings of too many names.
 <<[[labels.rules]]>>=
 # newsletters and digests
-from:Google\sScholar|Springer\sAlert|ScienceDirect  newsletter research
-from:Nature\sBriefing|News\sfrom\sScience           newsletter research
+stream:Google\sScholar|Springer\sAlert|ScienceDirectnewsletter research
+stream:Nature\sBriefing|News\sfrom\sScience         newsletter research
 subject:Aktuell\shögskolepedagogisk\sforskning      newsletter research
-from:ACM\sDigital\sLibrary|Xplore                   newsletter research
-from:(?-i:\b(IEEE|ACM|SIAM)\b)                      newsletter research
-from:The\sDownload|Times\sHigher\sEducation         newsletter
-from:(?-i:\bSANS\b)|EIT\sDigital                    newsletter
-from:KTH\s(Magazine|Opportunities\sFund|Alumni)     newsletter
+stream:ACM\sDigital\sLibrary|Xplore                 newsletter research
+stream:(?-i:\b(IEEE|ACM|SIAM)\b)                    newsletter research
+stream:The\sDownload|Times\sHigher\sEducation       newsletter
+stream:(?-i:\bSANS\b)|EIT\sDigital                  newsletter
+stream:KTH\s(Magazine|Opportunities\sFund|Alumni)   newsletter
 @
 
 

--- a/nymutt.nw
+++ b/nymutt.nw
@@ -322,6 +322,24 @@ output = subprocess.run(["./nymutt", "derive", "email5.txt"],
                         capture_output=True, env=demoenv)
 print_verbatim(output.stdout)
 \end{pycode}
+The last three examples are a thread about an assistant's contract:
+we ask the personnel office for it, the assistant replies, the office
+replies.
+[[edumail]] recognizes all three as assistant matters, and the seed
+rules add [[admin]] for the support desk on the two emails it is party
+to; the assistant's \enquote{rättat} in the second matches the rules'
+examination line, but [[edumail]] discards that label for mail about
+the course as a whole.
+No course appears, because none is named: the thread is about a
+person and a percentage.
+\begin{pycode}
+lines = []
+for email in ["email6.txt", "email7.txt", "email8.txt"]:
+    output = subprocess.run(["./nymutt", "derive", email],
+                            capture_output=True, env=demoenv)
+    lines.append(f"{email}: " + " ".join(output.stdout.decode().split()))
+print_verbatim("\n".join(lines))
+\end{pycode}
 
 \subsection{Opening an email}
 
@@ -891,6 +909,19 @@ Johan\sSnider                                       colleague CSE
 Simone\sFischer-H(ü|ue)bner                         swits research security
 subject:swits                                       swits research security
 @
+
+One kind of person the seed leaves out is the teaching assistant.
+[[edumail]] already gives their mail its role label ([[TA-management]]),
+but the role is not the bucket we sum up under; the course is, and
+contract and pay mail never names it---the last three of [[edumail]]'s
+example emails are a thread about one assistant's percentage in which
+the course is not mentioned once.
+The assistant's name is then the only evidence there is, so a line per
+assistant and term, mapping the name to the course they assist in,
+would put that mail where it belongs.
+The seed cannot know this term's assistants, and we have not yet
+maintained such lines by hand; it is noted here as the way to do it
+when the sums for [[TA-management]] need splitting by course.
 
 \subsection{Courses}
 


### PR DESCRIPTION
Two classifier changes in `edumail labels`, each with pseudonymized example emails and tests in the literate sources.

**`amanuens` alone triggers the assistant test.** It is a job title, so it counts as both the noun and the employment hint, and it is matched as a bare stem so the compounds in contract mail (`amanuensavtal`, `amanuensanställning`) match. A contract request used to derive nothing at all. The contract thread (`email6–8.txt`) is the example; `nymutt.nw` runs it with the seed rules and notes that a per-assistant name→course rule is the way to split `TA-management` by course when wanted.

**`stream:` rule prefix.** Mail from programs hit the keyword guesses: a cron job's `ssh: connect to host` and the `git` in GitHub's name made everything datintro (+ `LAB1`), and a rule could only add labels. A `stream:` rule matches `From:` like `from:` and declares the sender a program: for such mail, `labels` keeps only literal evidence (course codes, assignment groups) and the rules, skipping keyword families, module tests and the assistant test. Explicit prefix rather than a side effect of `from:`, so person rules and tool rules are told apart in the file. Every automated sender in the seed rules becomes `stream:`, plus a new `stream:Cron\sDaemon admin`. `email9.txt` (a failed backup) is the example; a cron Ladok report still yields `LAB1 admin examination ladok prgi`.

Also fixes the pre-existing `??` in edumail.pdf from a `\cref` into the other document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WR9Fk58dLGm1XvhRpnpB2J