### PR TITLE
Guess courses from the body only for student mail

### DIFF
--- a/edumail.nw
+++ b/edumail.nw
@@ -436,6 +436,46 @@ We also don't want to match the reply line.
 IGNORE_HEADERS="${IGNORE_HEADERS}|On .* wrote:$"
 @
 
+\subsection{Telling a student's email from a colleague's}
+\label{StudentDisclaimer}
+
+One line in an email is worth reading for who wrote it rather than for
+what it says.
+KTH appends a disclaimer to mail from outside---\enquote{avsändaren
+inte är anställd vid Kungliga Tekniska högskolan}, in Swedish and
+English---and it is the mail system, not the sender, that puts it
+there.
+<<functions>>=
+is_student() {
+  local file=$(file_or_stdin "$1")
+  grep -qiE "${STUDENT_DISCLAIMER}" "$file"
+}
+<<variables>>=
+STUDENT_DISCLAIMER="inte är anställd vid Kungliga Tekniska"
+STUDENT_DISCLAIMER="${STUDENT_DISCLAIMER}|is not employed by KTH"
+@
+
+The test reads the raw email rather than the cleaned one, and it does
+not care whether the line is quoted:
+in a reply to a student the disclaimer sits inside the quoted message,
+which is exactly the case we want to recognise.
+
+What the line proves runs one way only.
+It is there because the sender is not an employee, so seeing it settles
+that a student wrote the email; \emph{not} seeing it settles nothing,
+since it is a recent addition and the mail may be old or forwarded.
+\Cref{email2,email3} are student emails without it.
+Everything below therefore uses [[is_student]] to license a guess, never
+to forbid one.
+
+The line says something sharper than \enquote{a student}, which is
+worth recording even though nothing uses it yet:
+the sender is not employed \emph{by KTH}.
+A student who already assists on a course is an employee and loses the
+disclaimer, so on mail about assistants the line separates an applicant
+from someone who holds a position---\cref{email5}, an application, has
+it, and the contract thread (\cref{email6,email7,email8}) does not.
+
 \subsection{Extracting course identifiers from clean email}
 
 This leaves us with the following construction.
@@ -506,6 +546,7 @@ Members are named by nick name, the shorter and more stable of the two names.
 <<functions>>=
 course_families() {
   local file=$(file_or_stdin "$1")
+  <<narrow [[file]] to what we may guess from>>
   if <<test for datintro terms>>; then
     echo "datintro progd"
   fi
@@ -521,6 +562,47 @@ course_families() {
 }
 @ Note that we don't use [[elif]]: a student might write about several courses 
 in one email.
+
+\begin{example}\label{email11}
+An administrator writes about the credit card that pays for our
+subscriptions.
+\inputminted[highlightlines={4,21,44,65,83}]{text}{email11.txt}
+No course is named and none is meant.
+\end{example}
+
+These keywords are ordinary words, and that is the point:
+they are what a student writes who has not named the course.
+It is also their danger, because an email is more than what its author
+wrote.
+Under a colleague's signature stands the name of our school, which ends
+in \enquote{Computer Science}, and that is the science course's keyword;
+below it the quoted thread and the ordinary English of administration.
+\Cref{email11} collects three such hits and comes out belonging to four
+courses, having nothing to do with any of them.
+
+So we let the sender decide how far the guess may reach.
+When the disclaimer tells us a student wrote the email
+(\cref{StudentDisclaimer}), we search all of it, as before.
+Otherwise we search the subject line alone:
+a student who describes a course does it in the subject too---and the
+three false hits in \cref{email11} are all in the body.
+This is a restriction on guessing only.
+Course codes and nick names are read from the whole email whoever wrote
+it, since naming a course is deliberate.
+<<narrow [[file]] to what we may guess from>>=
+if ! is_student "$file"; then
+  local subject=$(mktemp)
+  grep -i "^Subject: " "$file" > "$subject"
+  file="${subject}"
+fi
+@ Rewriting [[file]] rather than the tests keeps the keywords in one
+place:
+[[clean]] leaves a subject line alone, so the four tests below read the
+narrowed email without knowing that it was narrowed.
+It also has to be here and not in [[<<look for>>]], which
+[[assignment_groups]] and the assistant test share:
+\cref{email10} states its appointment in the body, and narrowing that
+test to the subject would lose it.
 
 The course code of each nick name is a table.
 <<variables>>=
@@ -734,13 +816,13 @@ are in English---although Swedish students sometimes write their emails in
 Swedish if they have figured out that I'm fluent in Swedish.
 <<test for programming terms>>=
    <<look for>> "programm?ering|python|DD1310|DD1317" \
-|| <<look for>> "datorprov|projekt|p-uppgift|gransk|spec" \
+|| <<look for>> "datorprov|projekt|p-uppgift|gransk|\bspec" \
 || <<look for>> "lab(b|oration) [1-6]|Excel" \
 || <<look for>> "restlab"
 <<test for datintro terms>>=
    <<look for>> "data?intro|DD13(01|37)" \
 || <<look for>> "ssh|terminal|student-shell|bash|shell|Public" \
-|| <<look for>> "rättning|s[ck]ript" \
+|| <<look for>> "rättning|\bs[ck]ript" \
 || <<look for>> "git|latex"
 <<test for crypto terms>>=
    <<look for>> "[kc]rypto|DD2520" \
@@ -929,7 +1011,7 @@ LAB1 for the programming course is a series of labs.
 <<look for>> "datorprov|(kontroll|kort)skrivning|prov|tenta"
 @ LAB3 is the project assignment.
 <<test for programming LAB3 terms>>=
-<<look for>> "projekt|p-uppgift|gransk|spec"
+<<look for>> "projekt|p-uppgift|gransk|\bspec"
 @ KAL1 is the Excel part, consists of four labs in Excel.
 <<test for programming KAL1 terms>>=
 <<look for>> "Excel"
@@ -1793,6 +1875,24 @@ print_verbatim("\n".join(lines))
 \end{pycode}
 What the rules add to the thread is shown with the seed rules in the
 [[nymutt]] documentation.
+
+\Cref{email11} is what the guessing looked like before the sender
+decided its reach: it used to name four courses and three of their
+modules, on \enquote{sub\emph{script}ion},
+\enquote{e\emph{spec}ially} and the \enquote{Computer Science} of the
+school in the signature.
+Now it names none, and without a rules file there is nothing left to
+say about it:
+\begin{pycode}
+output = subprocess.run(["./edumail", "labels", "email11.txt"],
+                        capture_output=True, env=norules)
+print_verbatim(output.stdout or b"(nothing)\n")
+\end{pycode}
+The first two of those hits were bad matching rather than bad reach:
+\enquote{script} was inside \enquote{subscription} and \enquote{spec}
+inside \enquote{especially}, so both keywords now require a word
+boundary in front.
+That matters for the emails we still read in full, the students'.
 
 \Cref{email9} shows the guesses at work on a program's output, and what
 a [[stream:]] rule does about them.

--- a/email11.txt
+++ b/email11.txt
@@ -1,0 +1,120 @@
+Date: Fri, 4 Sep 2026 15:18:20 +0200
+From: Koordinatorn Koordinatorsson <koordinatorn@kth.se>
+To: Daniel Bosk <dbosk@kth.se>
+Subject: RE: Change credit card details in your subscriptions
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset=utf-8
+
+Hej Daniel,
+
+Vi ses kl. 9:00 via Zoom på måndag! 😊
+
+/Koordinatorn
+
+
+Koordinatorn Koordinatorsson
+Koordinator ledningsstöd / Management Coordinator 
+CST and TCS
+KTH Royal Institute of Technology
+Skolan för elektroteknik och datavetenskap /
+School of Electrical Engineering and Computer Science (EECS)
+Lindstedtsvägen 3-5, SE-100 44 Stockholm, Sweden
+koordinatorn@kth.se , www.kth.se/eecs 
+
+-----Original Message-----
+From: Daniel Bosk <dbosk@kth.se> 
+Sent: den 4 september 2026 14:49
+To: Koordinatorn Koordinatorsson <koordinatorn@kth.se>
+Subject: Re: Change credit card details in your subscriptions
+
+Booked! Took Monday 9--9:30 via Zoom. Hope that works. Not sure if I could read your calendar correctly (looked empty), I never use Outlook.
+
+      Have a great weekend!
+
+            Daniel
+
+On Fri Sep  4 12:11:27 2026, Koordinatorn Koordinatorsson wrote:
+> Hi everyone,
+> 
+>  
+> 
+> If you haven't reached out to me yet to plan for a short meeting to 
+> update the card details, please do so asap as I am on vacation from 15 
+> September for two weeks, especially if you have a monthly paid subscription/license.
+> 
+> You can check my Outlook calendar when I am available. Next Monday via 
+> Zoom, Tuesday and Wednesday at TCS or via Zoom, Thursday and Friday at 
+> CST or via Zoom.
+> 
+>  
+> 
+> Thank you.
+> 
+> Kind regards,
+> Koordinatorn
+> 
+>  
+> 
+> Koordinatorn Koordinatorsson
+> 
+> Koordinator ledningsstöd / Management Coordinator CST and TCS
+> 
+> KTH Royal Institute of Technology
+> Skolan för elektroteknik och datavetenskap / School of Electrical 
+> Engineering and Computer Science (EECS) Lindstedtsvägen 3-5, SE-100 44 
+> Stockholm, Sweden
+> koordinatorn@kth.se , www.kth.se/eecs
+> 
+>  
+> 
+> From: Upphandlaren Upphandlarsson <upphandlaren@kth.se>
+> Sent: den 3 september 2026 14:30
+> To: Daniel Bosk <dbosk@kth.se>; Kollegan Kollegasson <kollegan@kth.se>
+> Cc: Koordinatorn Koordinatorsson <koordinatorn@kth.se>
+> Subject: Change credit card details in your subscriptions
+> 
+>  
+> 
+> Hi all,
+> 
+>  
+> 
+> I'm leaving EECS Service center for a position with the Purchase and 
+> procurement group at KTH (Upphandlingsgruppen).
+> 
+> This means that my EECS credit card will be cancelled and without 
+> action all your different subscriptions will be cancelled with it.
+> 
+>  
+> 
+> Please contact Koordinatorn Koordinatorsson and schedule a meeting with 
+> her to change your payment information to her credit card instead.
+> 
+> And remember to send your receipts to her instead of me.
+> 
+>  
+> 
+> Don't hesitate to contact us if you have any further questions or 
+> concerns - have a great rest of your day!
+> 
+>  
+> 
+> Best regards,
+> 
+> Upphandlaren Upphandlarsson
+> 
+> Service- och inköpskoordinator
+> 
+> KTH Verksamhetsstöd
+> 
+> Infrastruktur och service
+> 
+> Skolan för elektronik och datavetenskap
+> 
+> Lindstedtsvägen 3, 114 28 Stockholm
+> 
+> upphandlaren@kth.se, www.kth.se
+> 
+>  
+> 

--- a/nymutt.nw
+++ b/nymutt.nw
@@ -354,6 +354,14 @@ output = subprocess.run(["./nymutt", "derive", "email9.txt"],
                         capture_output=True, env=demoenv)
 print_verbatim(output.stdout)
 \end{pycode}
+The eleventh is the administrator's message about the subscriptions.
+[[edumail]] finds no course in it---it is not from a student, so it
+guesses only from the subject---and the rules above supply the rest:
+\begin{pycode}
+output = subprocess.run(["./nymutt", "derive", "email11.txt"],
+                        capture_output=True, env=demoenv)
+print_verbatim(output.stdout)
+\end{pycode}
 
 \subsection{Opening an email}
 
@@ -983,6 +991,8 @@ service@eecs\.kth\.se                               admin
 pa-.*@.*\.kth\.se                                   admin
 Anna\sOlanås\sJansson                               admin hr
 Hanna\sHolmqvist                                    admin hr
+Anna\sMammitzsch                                    admin
+Marlene\sRohdin                                     admin
 it-support@kth\.se                                  it
 subject:ID:KTH-INC                                  admin
 e-learning@kth\.se                                  canvas admin
@@ -1103,6 +1113,18 @@ resubmissions are [[rest(er\b|labb|uppgift|inlämn)]].
 The remaining topics keep the [[subject:]] prefix; words like
 \enquote{timmar}, \enquote{sjuk} or \enquote{fråga} are far too common
 in running text to be labels on their own.
+The subscriptions we pay for by card are administration twice over:
+the tools are ours, but the card is the school's, and the mail comes
+from whoever holds it.
+The rule carries both labels for that reason, and matches the word in
+either language, since the same matter is written about in Swedish as
+\enquote{abonnemang}.
+The service centre gets a rule of its own because the people there
+change---the mail that prompted this was one coordinator handing over
+to another---while the desk stays.
+[[edumail]]'s example emails end with such a message, and the two rules
+are all it should yield.
+
 Cron mail is the one sender-based rule among the topics, and it is a
 [[stream:]] rule:
 reading a job's output is administration whatever the job printed, and
@@ -1132,6 +1154,8 @@ stream:Cron\sDaemon                                 admin
 subject:cron.*dbosk@rpi                             admin scripts
 stream:Calendly                                     meeting
 subject:receipt\sfrom\sAnthropic                    expenses admin
+subscription|abonnemang                             subscription admin
+service\s?cent(er|re)                               admin
 subject:(reviewer.*invitation|invitation.*reviewer) reviewing research
 stream:KTH\sSurvey                                  survey
 @


### PR DESCRIPTION
An administrator's email about the credit card behind our subscriptions (`email11.txt`) came out belonging to four courses and three of their modules:

```
INL1 LAB1 LAB3 datintro prgi prgm progd vetcyb
```

All of it came from the keyword *guess* — the fallback meant for students who describe a course without naming it — on three words nobody wrote about a course: `script` inside **sub**script**ion**, `spec` inside **e**spec**ially**, and the `scien` that ends "Computer Science" in the school name in every colleague's signature.

**The fix uses the KTH external-sender disclaimer.** It is appended when the sender is not an employee, so its presence proves a student wrote the email. It proves nothing by its absence — `email2` and `email3` are student mail without it — so it licenses the guess rather than forbidding it:

- disclaimer present → search the whole email, as before;
- otherwise → search the `Subject:` line only, where a student who describes a course puts it too.

Course codes and nick names are still read from the whole email whoever wrote it, since naming a course is deliberate. The narrowing is confined to `course_families`; the shared `<<look for>>` chunk is untouched, because `email10` states its appointment in the body and the assistant test must still see it.

The two substring hits are fixed at the source as well (`\bs[ck]ript`, `\bspec`), since student mail is still read in full.

| email | before | after |
|---|---|---|
| `email11` | 8 labels | `admin subscription` (+ `email` from nymutt) |
| `email9` | `LAB1 datintro progd` | guess gone; `admin` from its `stream:` rule |
| `email1`–`email8`, `email10` | | unchanged |

New seed rules: `subscription\|abonnemang → subscription admin`, `service\s?cent(er\|re) → admin`, and the two coordinators under administration and support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WR9Fk58dLGm1XvhRpnpB2J